### PR TITLE
Fix: Resolve 8 SonarCloud maintainability issues

### DIFF
--- a/noakweather-platform/weather-processing/src/test/java/weather/processing/parser/common/ParseResultTest.java
+++ b/noakweather-platform/weather-processing/src/test/java/weather/processing/parser/common/ParseResultTest.java
@@ -127,7 +127,7 @@ class ParseResultTest {
         ParseResult<String> result = ParseResult.success("test");
         
         StringBuilder builder = new StringBuilder();
-        result.ifSuccess(data -> builder.append(data));
+        result.ifSuccess(builder::append);
         
         assertEquals("test", builder.toString());
     }
@@ -138,7 +138,7 @@ class ParseResultTest {
         ParseResult<String> result = ParseResult.failure("error");
         
         StringBuilder builder = new StringBuilder();
-        result.ifSuccess(data -> builder.append(data));
+        result.ifSuccess(builder::append);
         
         assertEquals("", builder.toString());
     }
@@ -149,7 +149,7 @@ class ParseResultTest {
         ParseResult<String> result = ParseResult.failure("error message");
         
         StringBuilder builder = new StringBuilder();
-        result.ifFailure(error -> builder.append(error));
+        result.ifFailure(builder::append);
         
         assertEquals("error message", builder.toString());
     }
@@ -160,7 +160,7 @@ class ParseResultTest {
         ParseResult<String> result = ParseResult.success("test");
         
         StringBuilder builder = new StringBuilder();
-        result.ifFailure(error -> builder.append(error));
+        result.ifFailure(builder::append);
         
         assertEquals("", builder.toString());
     }
@@ -172,8 +172,8 @@ class ParseResultTest {
         StringBuilder failureBuilder = new StringBuilder();
         
         ParseResult<String> success = ParseResult.success("data");
-        success.ifSuccess(data -> successBuilder.append(data))
-               .ifFailure(error -> failureBuilder.append(error));
+        success.ifSuccess(successBuilder::append)
+           .ifFailure(failureBuilder::append);
         
         assertEquals("data", successBuilder.toString());
         assertEquals("", failureBuilder.toString());


### PR DESCRIPTION
- Replaced 6 lambdas with method references in ParseResultTest
  - Changed 'data -> builder.append(data)' to 'builder::append'
  - Applies to testIfSuccess, testIfFailure, and testChaining methods

- Refactored duplicate tests into parameterized tests in NoaaMetarParserTest
  - Combined 3 null/empty/whitespace tests into 1 parameterized test
  - Combined 3 various format tests into 1 parameterized test
  - Uses @ParameterizedTest, @NullAndEmptySource, @ValueSource, @CsvSource

Results:
- All 212 tests passing across platform (weather-common: 85, weather-processing: 127)
- Increased from 209 to 212 tests due to parameterized test expansions
- Code more maintainable with less duplication
- Follows JUnit 5 best practices
- Should resolve all 8 SonarCloud maintainability issues

Build Status:
- Full platform build: SUCCESS
- Zero failures, zero errors, zero skipped
- JaCoCo coverage reports generated