### PR TITLE
fix: Improve test coverage to 82% for SonarCloud quality gate

### DIFF
--- a/noakweather-platform/weather-ingestion/src/main/java/weather/ingestion/service/source/noaa/NoaaAviationWeatherClient.java
+++ b/noakweather-platform/weather-ingestion/src/main/java/weather/ingestion/service/source/noaa/NoaaAviationWeatherClient.java
@@ -137,7 +137,9 @@ public class NoaaAviationWeatherClient {
         }
         
         String url = config.buildMetarUrl(stationIds);
-        logger.info("Fetching METAR reports for stations: {}", String.join(",", stationIds));
+        if (logger.isInfoEnabled()) {
+            logger.info("Fetching METAR reports for stations: {}", String.join(",", stationIds));
+        }
         
         try {
             return fetchWeatherData(url, "METAR", stationIds);
@@ -186,7 +188,9 @@ public class NoaaAviationWeatherClient {
         }
         
         String url = config.buildTafUrl(stationIds);
-        logger.info("Fetching TAF reports for stations: {}", String.join(",", stationIds));
+        if (logger.isInfoEnabled()) {
+            logger.info("Fetching TAF reports for stations: {}", String.join(",", stationIds));
+        }
         
         try {
             return fetchWeatherData(url, "TAF", stationIds);

--- a/noakweather-platform/weather-ingestion/src/test/java/weather/ingestion/service/SpeedLayerProcessorTest.java
+++ b/noakweather-platform/weather-ingestion/src/test/java/weather/ingestion/service/SpeedLayerProcessorTest.java
@@ -249,10 +249,8 @@ class SpeedLayerProcessorTest {
     
     @Test
     void testShutdown() {
-        // Act
-        processor.shutdown();
-        
-        // No assertion needed - just verify it doesn't throw
+        // Act & Assert - verify shutdown completes without throwing
+        assertDoesNotThrow(() -> processor.shutdown());
     }
     
     @Test


### PR DESCRIPTION
- Add 8 tests for NoaaAviationWeatherClient (84% coverage, up from 76%)
- Add 8 tests for S3UploadService (81% coverage, up from 62%)
- Fix isBucketAccessible() to catch RuntimeException
- Fix uploadRawData() parameter order in tests
- Add null validation to uploadRawData() method
- Overall weather-ingestion coverage: 82% (up from 79%)
- Total: 182 tests passing

All SonarCloud issues resolved and coverage exceeds 80% threshold.