### PR TITLE
fix: Resolve 13 additional SonarCloud code quality issues

### DIFF
--- a/noakweather-platform/weather-common/src/test/java/weather/model/NoaaWeatherDataTest.java
+++ b/noakweather-platform/weather-common/src/test/java/weather/model/NoaaWeatherDataTest.java
@@ -506,7 +506,7 @@ class NoaaWeatherDataTest {
     
     @Test
     @DisplayName("Should handle equals when IDs are compared")
-    void testEqualsIdComparison() throws Exception {
+    void testEqualsIdComparison() {
         NoaaWeatherData data1 = new NoaaWeatherData("KJFK", now, "METAR");
         NoaaWeatherData data2 = new NoaaWeatherData("KJFK", now, "METAR");
         

--- a/noakweather-platform/weather-common/src/test/java/weather/model/WeatherDataTest.java
+++ b/noakweather-platform/weather-common/src/test/java/weather/model/WeatherDataTest.java
@@ -96,7 +96,7 @@ class WeatherDataTest {
     
     @Test
     @DisplayName("Should return false when comparing with null")
-    @SuppressWarnings("java:S5838") // Intentional: argument order needed to test equals() implementation
+    @SuppressWarnings({"java:S5838", "java:S3415"}) // Intentional: argument order needed to test equals() implementation
     void testEqualsWithNull() {
         TestWeatherData data = new TestWeatherData(WeatherDataSource.NOAA, "KJFK", now);
         

--- a/noakweather-platform/weather-ingestion/src/test/java/weather/ingestion/service/S3UploadServiceTest.java
+++ b/noakweather-platform/weather-ingestion/src/test/java/weather/ingestion/service/S3UploadServiceTest.java
@@ -280,40 +280,37 @@ class S3UploadServiceTest {
     }
     
     @Test
-    void testUploadRawDataNullSource() throws IOException {
+    void testUploadRawDataNullSource() {
         // Act & Assert
         IOException exception = assertThrows(IOException.class, () -> {
             uploadService.uploadRawData(null, "some data", "KJFK");
         });
         
-        assertNotNull(exception);
         assertTrue(exception.getMessage().contains("Source"));
     }
     
     @Test
-    void testUploadRawDataNullRawData() throws IOException {
+    void testUploadRawDataNullRawData() {
         // Act & Assert
         IOException exception = assertThrows(IOException.class, () -> {
             uploadService.uploadRawData("noaa", null, "KJFK");
         });
         
-        assertNotNull(exception);
         assertTrue(exception.getMessage().contains("Raw data"));
     }
     
     @Test
-    void testUploadRawDataNullStationId() throws IOException {
+    void testUploadRawDataNullStationId() {
         // Act & Assert
         IOException exception = assertThrows(IOException.class, () -> {
             uploadService.uploadRawData("noaa", "some data", null);
         });
         
-        assertNotNull(exception);
         assertTrue(exception.getMessage().contains("Station ID"));
     }
     
     @Test
-    void testUploadRawDataS3Exception() throws IOException {
+    void testUploadRawDataS3Exception() {
         // Arrange
         String source = "noaa";
         String rawData = "test data";
@@ -327,7 +324,7 @@ class S3UploadServiceTest {
             uploadService.uploadRawData(source, rawData, stationId);
         });
             
-        assertNotNull(exception);
+        assertTrue(exception.getMessage().contains("Failed to upload"));
     }
     
     @Test
@@ -373,35 +370,32 @@ class S3UploadServiceTest {
     }
     
     @Test
-    void testUploadRawDataEmptySource() throws IOException {
+    void testUploadRawDataEmptySource() {
         // Act & Assert
         IOException exception = assertThrows(IOException.class, () -> {
             uploadService.uploadRawData("", "some data", "KJFK");
         });
         
-        assertNotNull(exception);
         assertTrue(exception.getMessage().contains("Source"));
     }
     
     @Test
-    void testUploadRawDataEmptyRawData() throws IOException {
+    void testUploadRawDataEmptyRawData() {
         // Act & Assert
         IOException exception = assertThrows(IOException.class, () -> {
             uploadService.uploadRawData("noaa", "", "KJFK");
         });
         
-        assertNotNull(exception);
         assertTrue(exception.getMessage().contains("Raw data"));
     }
     
     @Test
-    void testUploadRawDataEmptyStationId() throws IOException {
+    void testUploadRawDataEmptyStationId() {
         // Act & Assert
         IOException exception = assertThrows(IOException.class, () -> {
             uploadService.uploadRawData("noaa", "some data", "");
         });
         
-        assertNotNull(exception);
         assertTrue(exception.getMessage().contains("Station ID"));
     }
 

--- a/noakweather-platform/weather-storage/src/test/java/weather/storage/repository/RepositoryStatsTest.java
+++ b/noakweather-platform/weather-storage/src/test/java/weather/storage/repository/RepositoryStatsTest.java
@@ -50,7 +50,7 @@ class RepositoryStatsTest {
     }
     
     @Test
-    @SuppressWarnings("java:S5838") // Intentional: tests equals() implementation
+    @SuppressWarnings({"java:S5838", "java:S3415"}) // Intentional: tests equals() implementation
     void testEqualsDifferentType() {
         RepositoryStats stats = new RepositoryStats(
             100L, LocalDateTime.now(), LocalDateTime.now(), 

--- a/noakweather-platform/weather-storage/src/test/java/weather/storage/repository/dynamodb/DynamoDbRepositoryTest.java
+++ b/noakweather-platform/weather-storage/src/test/java/weather/storage/repository/dynamodb/DynamoDbRepositoryTest.java
@@ -124,7 +124,7 @@ class DynamoDbRepositoryTest {
             () -> repository.save(null)
         );
         
-        assertNotNull(exception);
+        assertTrue(exception.getMessage().contains("not yet implemented"));
     }
     
     @Test
@@ -140,9 +140,11 @@ class DynamoDbRepositoryTest {
     
     @Test
     void testDeleteOlderThanThrowsUnsupportedOperation() {
+        LocalDateTime cutoffDate = LocalDateTime.now().minusMonths(6);
+        
         UnsupportedOperationException exception = assertThrows(
             UnsupportedOperationException.class, 
-            () -> repository.deleteOlderThan(LocalDateTime.now().minusMonths(6))
+            () -> repository.deleteOlderThan(cutoffDate)
         );
         
         assertTrue(exception.getMessage().contains("TTL"), 

--- a/noakweather-platform/weather-storage/src/test/java/weather/storage/repository/snowflake/SnowflakeRepositoryTest.java
+++ b/noakweather-platform/weather-storage/src/test/java/weather/storage/repository/snowflake/SnowflakeRepositoryTest.java
@@ -87,7 +87,7 @@ class SnowflakeRepositoryTest {
             () -> repository.save(null)
         );
         
-        assertNotNull(exception, "Exception should not be null");
+        assertTrue(exception.getMessage().contains("not yet implemented"));
     }
     
     @Test
@@ -103,9 +103,11 @@ class SnowflakeRepositoryTest {
     
     @Test
     void testDeleteOlderThanThrowsException() {
+        LocalDateTime cutoffDate = LocalDateTime.now();
+        
         UnsupportedOperationException exception = assertThrows(
             UnsupportedOperationException.class, 
-            () -> repository.deleteOlderThan(LocalDateTime.now())
+            () -> repository.deleteOlderThan(cutoffDate)
         );
     
         // Optionally verify message contains expected text

--- a/noakweather-platform/weather-storage/src/test/java/weather/storage/service/BatchLayerProcessorTest.java
+++ b/noakweather-platform/weather-storage/src/test/java/weather/storage/service/BatchLayerProcessorTest.java
@@ -353,7 +353,7 @@ class BatchLayerProcessorTest {
     }
     
     @Test
-    @SuppressWarnings("java:S5838") // Intentional: tests equals() implementation
+    @SuppressWarnings({"java:S5838", "java:S3415"}) // Intentional: tests equals() implementation
     void testBatchProcessingResultEqualsDifferentType() {
         BatchProcessingResult result = BatchProcessingResult.success()
             .source(WeatherDataSource.NOAA)
@@ -539,7 +539,7 @@ class BatchLayerProcessorTest {
     }
 
     @Test
-    @SuppressWarnings("java:S5838") // Intentional: tests equals() implementation
+    @SuppressWarnings({"java:S5838", "java:S3415"}) // Intentional: tests equals() implementation
     void testBatchProcessingStatsEqualsDifferentType() {
         BatchProcessingStats stats = new BatchProcessingStats(
             10, 1000L, 50L, LocalDateTime.now(), 5000L
@@ -788,7 +788,7 @@ class BatchLayerProcessorTest {
         // Execute the future and verify it throws the expected exception
         ExecutionException exception = assertThrows(
             ExecutionException.class,
-            () -> future.get(),
+            future::get,
             "Future should complete exceptionally"
         );
         


### PR DESCRIPTION
- Removed unnecessary throws Exception/IOException declarations
- Removed redundant assertNotNull after assertThrows
- Added S3415 to @SuppressWarnings for equals() tests
- Extracted date calculations from assertThrows lambdas
- Replaced lambda with method reference (future::get)

Files modified:
- NoaaWeatherDataTest.java
- WeatherDataTest.java
- S3UploadServiceTest.java
- RepositoryStatsTest.java
- DynamoDbRepositoryTest.java
- SnowflakeRepositoryTest.java
- BatchLayerProcessorTest.java

All 794 tests passing, code quality improved