### PR TITLE
fix: resolve final SonarQube blockers and code quality issues

### DIFF
--- a/noakweather-platform/weather-common/src/test/java/weather/model/NoaaMetarDataTest.java
+++ b/noakweather-platform/weather-common/src/test/java/weather/model/NoaaMetarDataTest.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * Tests for NoaaMetarData class.
@@ -892,9 +893,9 @@ class NoaaMetarDataTest {
         data2.setWind(new Wind(290, 20, null, null, null, "KT"));
         
         // Different objects MAY have different hash codes (not required, but likely)
-        // We're just verifying hashCode doesn't throw an exception
-        data1.hashCode();
-        data2.hashCode();
+        // We are just verifying hashCode does not throw an exception
+        assertThatCode(() -> data1.hashCode()).doesNotThrowAnyException();
+        assertThatCode(() -> data2.hashCode()).doesNotThrowAnyException();
     }
     
     @Test
@@ -905,7 +906,8 @@ class NoaaMetarDataTest {
         NoaaMetarData data2 = new NoaaMetarData("KLGA", now);
         
         // Different parent fields should (likely) result in different hash codes
-        data1.hashCode();
-        data2.hashCode();
+        // Verify hashCode() executes without throwing exception
+        assertThatCode(() -> data1.hashCode()).doesNotThrowAnyException();
+        assertThatCode(() -> data2.hashCode()).doesNotThrowAnyException();
     }
 }

--- a/noakweather-platform/weather-common/src/test/java/weather/model/WeatherDataTest.java
+++ b/noakweather-platform/weather-common/src/test/java/weather/model/WeatherDataTest.java
@@ -361,10 +361,6 @@ class WeatherDataTest {
     void testEqualsWithDifferentClass() {
         TestWeatherData data = new TestWeatherData(WeatherDataSource.NOAA, "KJFK", now);
         
-        // REMOVE !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-        //assertThat(data).isNotEqualTo("Not a WeatherData object");
-        //assertThat(data).isNotEqualTo(42);
-        
         assertThat(data)
                 .isNotEqualTo("Not a WeatherData object")
                 .isNotEqualTo(42);


### PR DESCRIPTION
- Add explicit assertions to hashCode tests using assertThatCode()
- Fix java:S2699 (tests must include assertions) in testHashCode_DifferentObjects
- Fix java:S2699 (tests must include assertions) in testHashCode_IncludesParentFields
- Remove commented out code (java:S125)
- Review and mark 5 security hotspots as safe (ReDoS in trusted METAR parsing)

All SonarQube issues resolved:
- 2 blocker issues: FIXED
- 1 medium issue: FIXED
- 5 security hotspots: REVIEWED

Quality Gate: Expected PASSED
Coverage: 99%+ maintained
All tests passing