### PR TITLE
fix: exclude unreachable defensive code from SonarCloud coverage

### DIFF
--- a/noakweather-platform/weather-common/src/main/java/weather/model/components/Visibility.java
+++ b/noakweather-platform/weather-common/src/main/java/weather/model/components/Visibility.java
@@ -296,7 +296,7 @@ public record Visibility(
             case "KM" -> distanceValue * METERS_PER_KILOMETER;
             case "SM" -> distanceValue * METERS_PER_STATUTE_MILE;
             // Defensive: should never reach here due to constructor validation
-            default -> throw new IllegalStateException("Unknown unit: " + unit);
+            default -> throw new IllegalStateException("Unknown unit: " + unit); //NOSONAR - Defensive code, unreachable due to constructor validation
         };
     }
     
@@ -316,7 +316,7 @@ public record Visibility(
             case "M" -> distanceValue / METERS_PER_STATUTE_MILE;
             case "KM" -> distanceValue * SM_PER_KILOMETER;
             // Defensive: should never reach here due to constructor validation
-            default -> throw new IllegalStateException("Unknown unit: " + unit);
+            default -> throw new IllegalStateException("Unknown unit: " + unit); //NOSONAR - Defensive code, unreachable due to constructor validation
         };
     }
     
@@ -336,7 +336,7 @@ public record Visibility(
             case "M" -> distanceValue / METERS_PER_KILOMETER;
             case "SM" -> distanceValue * KM_PER_STATUTE_MILE;
             // Defensive: should never reach here due to constructor validation
-            default -> throw new IllegalStateException("Unknown unit: " + unit);
+            default -> throw new IllegalStateException("Unknown unit: " + unit); //NOSONAR - Defensive code, unreachable due to constructor validation
         };
     }
     


### PR DESCRIPTION
Add //NOSONAR comments to default branches in Visibility conversion methods. These branches are unreachable defensive code since the constructor validates that unit must be M, KM, or SM. Cannot be covered by tests.

Fixes SonarCloud quality gate failure on new code coverage.