### PR TITLE
Fix: Remove duplicate fields in Bronze layer JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Bronze layer JSON duplicate fields** (weather-common)
+  - Bronze layer JSON output contained duplicate fields (`dataType`, `wind`,
+    `visibility`, `temperature`, `pressure`, `skyConditions`, `presentWeather`,
+    `automated`) causing AWS Glue Spark `AnalysisException: Found duplicate
+      column(s) in the data schema` and blocking Bronze-to-Silver ETL processing
+  - Root cause: `NoaaWeatherData`, `NoaaMetarData`, and `NoaaTafData` exposed
+    convenience getters delegating to `WeatherConditions`, which Jackson
+    serialized both as nested `conditions.*` fields and as flattened
+    top-level properties via default bean introspection
+  - `getDataType()` overrides also duplicated the `dataType` property
+    already injected by `@JsonTypeInfo`'s polymorphic type discriminator
+  - Added `@JsonIgnore` to all convenience getters (`getWind()`,
+    `getVisibility()`, `getPresentWeather()`, `getSkyConditions()`,
+    `getTemperature()`, `getPressure()`, `getCeilingFeet()`) and
+    `getDataType()` overrides in `NoaaWeatherData`, `NoaaMetarData`, and
+    `NoaaTafData`
+  - Added `@JsonIgnore` to `isAutomated()` in `NoaaMetarData` (derived
+    boolean duplicating `automatedStation` information)
+  - `WeatherConditions` (via `getConditions()`) remains the single source
+    of truth for serialized weather condition data
+  - Verified with fresh Bronze JSON generation and `jq` duplicate-key check
+
 ### Version 1.16.0-SNAPSHOT - February 08, 2026
 
 #### Weather Model & Processing - Unparsed Main Body Token Capture

--- a/noakweather-platform/weather-common/src/main/java/weather/model/NoaaMetarData.java
+++ b/noakweather-platform/weather-common/src/main/java/weather/model/NoaaMetarData.java
@@ -16,6 +16,7 @@
  */
 package weather.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import weather.model.components.remark.*;
 
@@ -237,6 +238,7 @@ public class NoaaMetarData extends NoaaWeatherData {
      *
      * @return true if automated
      */
+    @JsonIgnore
     public boolean isAutomated() {
         return automatedStation != null &&
                 (automatedStation.equals("AO1") || automatedStation.equals("AO2"));
@@ -264,7 +266,10 @@ public class NoaaMetarData extends NoaaWeatherData {
     // ========== OVERRIDES ==========
 
     @Override
-    public String getDataType() { return OBSERVATION_TYPE; }
+    @JsonIgnore
+    public String getDataType() {
+        return OBSERVATION_TYPE;
+    }
 
     @Override
     public String getSummary() {

--- a/noakweather-platform/weather-common/src/main/java/weather/model/NoaaTafData.java
+++ b/noakweather-platform/weather-common/src/main/java/weather/model/NoaaTafData.java
@@ -16,6 +16,7 @@
  */
 package weather.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import weather.model.components.ForecastPeriod;
 import weather.model.components.ValidityPeriod;
@@ -41,8 +42,8 @@ import java.util.Objects;
  * <p>
  * Example TAF:
  * TAF AMD KCLT 151953Z 1520/1624 VRB02KT P6SM FEW250
- *      FM152100 21005KT P6SM SCT250
- *      TEMPO 3003/3011 P6SM -SHSN BKN040 BKN160
+ * FM152100 21005KT P6SM SCT250
+ * TEMPO 3003/3011 P6SM -SHSN BKN040 BKN160
  * <p>
  * Architecture:
  * - Uses ValidityPeriod for overall forecast validity
@@ -204,7 +205,7 @@ public class NoaaTafData extends NoaaWeatherData {
      * Convenience method to set both max temperature and its occurrence time.
      *
      * @param temperature max temperature in Celsius
-     * @param time when max temperature occurs
+     * @param time        when max temperature occurs
      */
     public void setMaxTemperatureForecast(Integer temperature, Instant time) {
         this.maxTemperature = temperature;
@@ -215,7 +216,7 @@ public class NoaaTafData extends NoaaWeatherData {
      * Convenience method to set both min temperature and its occurrence time.
      *
      * @param temperature min temperature in Celsius
-     * @param time when min temperature occurs
+     * @param time        when min temperature occurs
      */
     public void setMinTemperatureForecast(Integer temperature, Instant time) {
         this.minTemperature = temperature;
@@ -372,7 +373,10 @@ public class NoaaTafData extends NoaaWeatherData {
     }
 
     @Override
-    public String getDataType() { return "TAF"; }
+    @JsonIgnore
+    public String getDataType() {
+        return "TAF";
+    }
 
     @Override
     public String getSummary() {

--- a/noakweather-platform/weather-common/src/main/java/weather/model/NoaaWeatherData.java
+++ b/noakweather-platform/weather-common/src/main/java/weather/model/NoaaWeatherData.java
@@ -16,6 +16,7 @@
  */
 package weather.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import weather.model.components.*;
 import weather.model.components.remark.NoaaMetarRemarks;
@@ -174,6 +175,7 @@ public non-sealed class NoaaWeatherData extends WeatherData {
      *
      * @return wind, or null if no conditions
      */
+    @JsonIgnore
     public Wind getWind() {
         return conditions != null ? conditions.wind() : null;
     }
@@ -184,6 +186,7 @@ public non-sealed class NoaaWeatherData extends WeatherData {
      *
      * @return visibility, or null if no conditions
      */
+    @JsonIgnore
     public Visibility getVisibility() {
         return conditions != null ? conditions.visibility() : null;
     }
@@ -194,6 +197,7 @@ public non-sealed class NoaaWeatherData extends WeatherData {
      *
      * @return list of present weather, empty list if no conditions
      */
+    @JsonIgnore
     public List<PresentWeather> getPresentWeather() {
         return conditions != null && conditions.presentWeather() != null
                 ? conditions.presentWeather()
@@ -206,6 +210,7 @@ public non-sealed class NoaaWeatherData extends WeatherData {
      *
      * @return immutable list of sky conditions, empty list if no conditions
      */
+    @JsonIgnore
     public List<SkyCondition> getSkyConditions() {
         return conditions != null && conditions.skyConditions() != null
                 ? List.copyOf(conditions.skyConditions())
@@ -218,6 +223,7 @@ public non-sealed class NoaaWeatherData extends WeatherData {
      *
      * @return temperature, or null if no conditions
      */
+    @JsonIgnore
     public Temperature getTemperature() {
         return conditions != null ? conditions.temperature() : null;
     }
@@ -228,6 +234,7 @@ public non-sealed class NoaaWeatherData extends WeatherData {
      *
      * @return pressure, or null if no conditions
      */
+    @JsonIgnore
     public Pressure getPressure() {
         return conditions != null ? conditions.pressure() : null;
     }
@@ -332,6 +339,7 @@ public non-sealed class NoaaWeatherData extends WeatherData {
      *
      * @return ceiling in feet, or null if no ceiling
      */
+    @JsonIgnore
     public Integer getCeilingFeet() {
         if (conditions == null) {
             return null;
@@ -422,6 +430,7 @@ public non-sealed class NoaaWeatherData extends WeatherData {
     }
 
     @Override
+    @JsonIgnore
     public String getDataType() {
         return reportType != null ? reportType : "NOAA";
     }
@@ -475,7 +484,7 @@ public non-sealed class NoaaWeatherData extends WeatherData {
         return Objects.equals(reportType, that.reportType) &&
                 Objects.equals(conditions, that.conditions) &&
                 Objects.equals(runwayVisualRange, that.runwayVisualRange) &&
-                Objects.equals(rawText, that.rawText)  &&
+                Objects.equals(rawText, that.rawText) &&
                 Objects.equals(unparsedMainBody, that.unparsedMainBody) &&
                 Objects.equals(reportModifier, that.reportModifier) &&
                 Objects.equals(remarks, that.remarks);


### PR DESCRIPTION
Issue: Bronze layer JSON contained duplicate fields (dataType, wind, visibility, temperature, pressure, skyConditions, presentWeather, automated) because NoaaWeatherData/NoaaMetarData/NoaaTafData exposed convenience getters that delegate to the WeatherConditions object, which Jackson serialized both as nested conditions.* fields AND as flattened top-level fields via default bean introspection.

Root cause:
- WeatherData uses @JsonTypeInfo to inject a 'dataType' discriminator property automatically
- NoaaWeatherData/NoaaMetarData/NoaaTafData also override getDataType() as a regular bean getter, which Jackson serialized independently, producing two 'dataType' keys
- Convenience getters (getWind(), getVisibility(), getTemperature(), getPressure(), getSkyConditions(), getPresentWeather(), getCeilingFeet()) delegate to conditions but were also serialized as top-level properties alongside the nested 'conditions' object
- isAutomated() in NoaaMetarData produced a derived 'automated' boolean property duplicating information already present in 'automatedStation'

Fix: Added @JsonIgnore to all convenience getters and getDataType() overrides in NoaaWeatherData, NoaaMetarData, and NoaaTafData, so WeatherConditions (via getConditions()) remains the single source of truth for serialized wind/visibility/temperature/pressure/sky data, and @JsonTypeInfo remains the sole source of the 'dataType' property.

Verified: Regenerated a fresh Bronze JSON for KATL via MetarIngestionApp and confirmed with jq that no duplicate keys exist in the output.

Updated CHANGELOG.md with Fixed entry under [Unreleased].

Impact: Resolves AWS Glue Spark AnalysisException 'Found duplicate column(s) in the data schema: dataType' that was blocking the Bronze-to-Silver ETL job.