### PR TITLE
Resolve SonarCloud maintainability and reliability issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Version 1.17.1-SNAPSHOT - August 28, 2026
+
+#### SonarCloud Maintainability and Reliability Fixes
+
+**Fixed:**
+- **Implicit time zone in timestamp generation** (weather-ingestion)
+  - `S3UploadService` and `SpeedLayerProcessor` used `LocalDateTime.now()`
+    without specifying a zone, implicitly relying on the JVM's default
+    system time zone (SonarCloud java:S8688)
+  - Both now explicitly use `LocalDateTime.now(ZoneOffset.UTC)`, consistent
+    with the platform's UTC-based timestamp convention
+
+- **Duplicated null/empty validation logic** (weather-ingestion)
+  - `S3UploadService` had a 9-line null/empty check pattern duplicated
+    across multiple methods for `source`, `rawData`, and `stationId`
+  - Extracted into a shared `requireNonEmpty(String value, String paramName)`
+    helper, applied consistently across all three parameters at both
+    `uploadRawData()` and `uploadRawDataWithPartitioning()`
+
+- **Non-linear regex backtracking risk** (weather-processing)
+  - `RegExprConst.PRESENT_WEATHER_PATTERN` chained multiple optional,
+    alternation-based repeating groups, a pattern shape that can exhibit
+    catastrophic backtracking on malformed input (SonarCloud java:S8786)
+  - Rewrote repeating groups with possessive quantifiers and non-capturing
+    groups to eliminate backtracking ambiguity while preserving identical
+    matching behavior for valid input
+  - `NoaaMetarParser`'s simple `\s+RMK\s+` split pattern was flagged by
+    the same rule but assessed as a false positive (no alternation, no
+    nested quantifiers); suppressed with `@SuppressWarnings("java:S8786")`
+
+- **Dangling Javadoc comment** (weather-processing)
+  - Removed an orphaned Javadoc block in `WeatherParserTest` that was not
+    properly attached to the class declaration (SonarCloud java:S8491)
+
+**Testing:**
+- Full test suite passing (0 failures, 0 errors) after fixes, including
+  regression coverage for the validation logic extraction (8 previously
+  passing `S3UploadServiceTest` cases initially broke when the duplicate
+  extraction only covered `source` and omitted `rawData`/`stationId`
+  validation; corrected before commit)
+
 ### Version 1.17.0-SNAPSHOT - August 27, 2026
 
 #### AWS Glue Bronze-to-Silver ETL Pipeline - METAR Observations

--- a/noakweather-platform/pom.xml
+++ b/noakweather-platform/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>weather</groupId>
     <artifactId>noakweather-platform</artifactId>
-    <version>1.17.0-SNAPSHOT</version>
+    <version>1.17.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>NoakWeather Engineering Pipeline</name>

--- a/noakweather-platform/weather-analytics/pom.xml
+++ b/noakweather-platform/weather-analytics/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.17.0-SNAPSHOT</version>
+        <version>1.17.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-analytics</artifactId>

--- a/noakweather-platform/weather-common/pom.xml
+++ b/noakweather-platform/weather-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.17.0-SNAPSHOT</version>
+        <version>1.17.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-common</artifactId>

--- a/noakweather-platform/weather-infrastructure/pom.xml
+++ b/noakweather-platform/weather-infrastructure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.17.0-SNAPSHOT</version>
+        <version>1.17.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-infrastructure</artifactId>

--- a/noakweather-platform/weather-ingestion/pom.xml
+++ b/noakweather-platform/weather-ingestion/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.17.0-SNAPSHOT</version>
+        <version>1.17.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-ingestion</artifactId>

--- a/noakweather-platform/weather-ingestion/src/main/java/weather/ingestion/service/S3UploadService.java
+++ b/noakweather-platform/weather-ingestion/src/main/java/weather/ingestion/service/S3UploadService.java
@@ -35,6 +35,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.time.ZoneId;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 /**
  * Service for uploading weather data to Amazon S3.
@@ -43,16 +44,16 @@ import java.time.LocalDateTime;
  * UPDATED: Now supports DUAL STORAGE - both raw text and JSON formats
  * <p>
  * S3 Structure:
- *   s3://bucket-name/
- *     └── bronze/
- *         ├── raw-data/
- *         │   └── noaa/
- *         │       ├── metar/2025/02/02/KJFK_20250202_1430.txt
- *         │       └── taf/2025/02/02/KLGA_20250202_1430.txt
- *         └── speed-layer/
- *              └── noaa/
- *                  ├── metar/2025/02/02/KJFK_20250202_1430.json
- *                  └── taf/2025/02/02/KLGA_20250202_1430.json
+ * s3://bucket-name/
+ * └── bronze/
+ * ├── raw-data/
+ * │   └── noaa/
+ * │       ├── metar/2025/02/02/KJFK_20250202_1430.txt
+ * │       └── taf/2025/02/02/KLGA_20250202_1430.txt
+ * └── speed-layer/
+ * └── noaa/
+ * ├── metar/2025/02/02/KJFK_20250202_1430.json
+ * └── taf/2025/02/02/KLGA_20250202_1430.json
  * <p>
  * NEW FUNCTIONALITY - Not present in legacy system
  *
@@ -73,7 +74,7 @@ public class S3UploadService {
      * Creates an S3UploadService with specified bucket and region.
      *
      * @param bucketName the S3 bucket name for weather data
-     * @param region the AWS region (e.g., "us-east-1")
+     * @param region     the AWS region (e.g., "us-east-1")
      */
     public S3UploadService(String bucketName, String region) {
         this.bucketName = bucketName;
@@ -92,7 +93,7 @@ public class S3UploadService {
     /**
      * Constructor for dependency injection (testing).
      *
-     * @param s3Client custom S3 client
+     * @param s3Client   custom S3 client
      * @param bucketName the S3 bucket name
      */
     public S3UploadService(S3Client s3Client, String bucketName) {
@@ -187,16 +188,29 @@ public class S3UploadService {
     }
 
     /**
+     * Validates that a required String parameter is neither null nor empty.
+     *
+     * @param value the data source (e.g., "NOAA", "OpenWeather")
+     * @param paramName the name of the parameter, used in the exception message
+     * @throws IOException if data source is empty
+     */
+    private static void requireNonEmpty(String value, String paramName) throws IOException {
+        if (value == null || value.isEmpty()) {
+            throw new IOException(paramName + " cannot be null or empty");
+        }
+    }
+
+    /**
      * Enhanced version of uploadRawData with date partitioning.
      * Stores raw text in the same partitioned structure as JSON for consistency.
      * <p>
      * Pattern: bronze/raw-data/{source}/{type}/{year}/{month}/{day}/{station}_{timestamp}.txt
      * Example: bronze/raw-data/noaa/metar/2025/02/02/KCLT_20250202_1430.txt
      *
-     * @param source the data source (e.g., "NOAA", "OpenWeather")
-     * @param rawData the raw data string
-     * @param stationId the station identifier
-     * @param dataType the data type (e.g., "METAR", "TAF")
+     * @param source        the data source (e.g., "NOAA", "OpenWeather")
+     * @param rawData       the raw data string
+     * @param stationId     the station identifier
+     * @param dataType      the data type (e.g., "METAR", "TAF")
      * @param ingestionTime the time data was ingested
      * @return the S3 key where data was stored
      * @throws IOException if upload fails
@@ -204,15 +218,9 @@ public class S3UploadService {
     private String uploadRawDataWithPartitioning(String source, String rawData,
                                                  String stationId, String dataType,
                                                  Instant ingestionTime) throws IOException {
-        if (source == null || source.isEmpty()) {
-            throw new IOException("Source cannot be null or empty");
-        }
-        if (rawData == null || rawData.isEmpty()) {
-            throw new IOException("Raw data cannot be null or empty");
-        }
-        if (stationId == null || stationId.isEmpty()) {
-            throw new IOException("Station ID cannot be null or empty");
-        }
+        requireNonEmpty(source, "Source");
+        requireNonEmpty(rawData, "Raw data");
+        requireNonEmpty(stationId, "Station ID");
         if (dataType == null || dataType.isEmpty()) {
             throw new IOException("Data type cannot be null or empty");
         }
@@ -349,27 +357,19 @@ public class S3UploadService {
      * NOTE: For NOAA data, use uploadWeatherDataDual() instead which provides
      * partitioned storage for both raw text and JSON.
      *
-     * @param source the data source (e.g., "noaa", "openweather")
-     * @param rawData the raw data string
+     * @param source    the data source (e.g., "noaa", "openweather")
+     * @param rawData   the raw data string
      * @param stationId the station identifier
      * @return the S3 key where data was stored
      * @throws IOException if upload fails
      */
     public String uploadRawData(String source, String rawData, String stationId) throws IOException {
         // Add null checks FIRST
-        if (source == null || source.isEmpty()) {
-            throw new IOException("Source cannot be null or empty");
-        }
+        requireNonEmpty(source, "Source");
+        requireNonEmpty(rawData, "Raw data");
+        requireNonEmpty(stationId, "Station ID");
 
-        if (rawData == null || rawData.isEmpty()) {
-            throw new IOException("Raw data cannot be null or empty");
-        }
-
-        if (stationId == null || stationId.isEmpty()) {
-            throw new IOException("Station ID cannot be null or empty");
-        }
-
-        String timestamp = java.time.LocalDateTime.now().format(TIMESTAMP_FORMAT);
+        String timestamp = java.time.LocalDateTime.now(ZoneOffset.UTC).format(TIMESTAMP_FORMAT);
         String s3Key = String.format("bronze/raw-data/%s/%s_%s.txt",
                 source.toLowerCase(), stationId, timestamp);
 
@@ -434,7 +434,7 @@ public class S3UploadService {
      * - Validation in compact constructor
      *
      * @param rawTextKey S3 key for the raw text file
-     * @param jsonKey S3 key for the JSON file
+     * @param jsonKey    S3 key for the JSON file
      */
     public record DualStorageResult(String rawTextKey, String jsonKey) {
         /**

--- a/noakweather-platform/weather-ingestion/src/main/java/weather/ingestion/service/SpeedLayerProcessor.java
+++ b/noakweather-platform/weather-ingestion/src/main/java/weather/ingestion/service/SpeedLayerProcessor.java
@@ -28,6 +28,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.*;
+import java.time.ZoneOffset;
 
 /**
  * Speed Layer Processor for Lambda Architecture.
@@ -75,7 +76,7 @@ public class SpeedLayerProcessor {
     /**
      * Creates a SpeedLayerProcessor with custom concurrency limit.
      *
-     * @param s3Service the S3 upload service
+     * @param s3Service             the S3 upload service
      * @param maxConcurrentRequests maximum number of concurrent S3 uploads
      */
     public SpeedLayerProcessor(S3UploadService s3Service, int maxConcurrentRequests) {
@@ -220,7 +221,7 @@ public class SpeedLayerProcessor {
      */
     private void enrichWithMetadata(WeatherData weatherData) {
         weatherData.addMetadata("validated", "true");
-        weatherData.addMetadata("validation_timestamp", LocalDateTime.now().toString());
+        weatherData.addMetadata("validation_timestamp", LocalDateTime.now(ZoneOffset.UTC).toString());
         weatherData.addMetadata("processor", "SpeedLayerProcessor");
         weatherData.addMetadata("processor_version", "2.1"); // Updated version for dual storage
         weatherData.addMetadata("storage_format", "dual"); // NEW: indicates both formats stored

--- a/noakweather-platform/weather-processing/pom.xml
+++ b/noakweather-platform/weather-processing/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.17.0-SNAPSHOT</version>
+        <version>1.17.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-processing</artifactId>

--- a/noakweather-platform/weather-processing/src/main/java/weather/processing/parser/noaa/NoaaMetarParser.java
+++ b/noakweather-platform/weather-processing/src/main/java/weather/processing/parser/noaa/NoaaMetarParser.java
@@ -148,7 +148,8 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * @return array with [mainBody, remarks]
      */
     private String[] splitMainBodyAndRemarks(String token) {
-        String[] parts = token.split("\\s+RMK\\s+", 2);
+        @SuppressWarnings("java:S8786")
+        String[] parts = token.split("\\s++RMK\\s++", 2);
         String mainBody = parts[0];
         String remarks = parts.length > 1 ? parts[1] : "";
         return new String[]{mainBody, remarks};

--- a/noakweather-platform/weather-processing/src/main/java/weather/processing/parser/noaa/RegExprConst.java
+++ b/noakweather-platform/weather-processing/src/main/java/weather/processing/parser/noaa/RegExprConst.java
@@ -21,9 +21,9 @@ import java.util.regex.Pattern;
 /**
  * Class representing the regular expressions used for decoding Metar and
  * TAF data
- * 
+ *
  * @author bclasky1539
- * 
+ *
  */
 public final class RegExprConst {
 
@@ -102,7 +102,7 @@ public final class RegExprConst {
      */
     @SuppressWarnings("java:S5843") // Complex regex required for multiple visibility formats
     public static final Pattern VISIBILITY_PATTERN = Pattern.compile(
-        "^(?<vis>(?<dist>[MP]?\\d{4}|////)(?<dir>[NSEW][EW]?|NDV)?|(?<distu>[MP]?(\\d+|\\d{1,2}/\\d{1,2}|\\d+\\s+\\d/\\d))(?<units>SM|KM|M|U)|NDV|CAVOK)\\s+"
+            "^(?<vis>(?<dist>[MP]?\\d{4}|////)(?<dir>[NSEW][EW]?|NDV)?|(?<distu>[MP]?(\\d+|\\d{1,2}/\\d{1,2}|\\d+\\s+\\d/\\d))(?<units>SM|KM|M|U)|NDV|CAVOK)\\s+"
     );
 
     /**
@@ -112,7 +112,7 @@ public final class RegExprConst {
      */
     @SuppressWarnings("java:S5843") // Complex regex required for runway visual range format
     public static final Pattern RUNWAY_PATTERN = Pattern.compile(
-        "^(RVRNO|R(?<name>\\d{2}(?<inden>[RLC])?))/(?<low>[MP]?(?<lvalue>CLRD|\\d{1,4}))(V(?<high>[MP]?\\d{4}))?/?/?/?/?(?<unit>\\d{2,4}|FT|N|D|U)?\\s+"
+            "^(RVRNO|R(?<name>\\d{2}(?<inden>[RLC])?))/(?<low>[MP]?(?<lvalue>CLRD|\\d{1,4}))(V(?<high>[MP]?\\d{4}))?/?/?/?/?(?<unit>\\d{2,4}|FT|N|D|U)?\\s+"
     );
 
     /**
@@ -122,7 +122,7 @@ public final class RegExprConst {
      */
     @SuppressWarnings("java:S5843") // Complex regex required for weather phenomena combinations
     public static final Pattern PRESENT_WEATHER_PATTERN = Pattern.compile(
-            "^(?<int>(VC|-|\\+)*)(?<desc>(MI|PR|BC|DR|BL|SH|TS|FZ)+)?(?<prec>(DZ|RA|SN|SG|IC|PL|GR|GS|UP|/)*)(?<obsc>BR|FG|FU|VA|DU|SA|HZ|PY)?(?<other>PO|SQ|FC|SS|DS|NSW|/+)?(?<int2>[-+])?\\s+"
+            "^(?<int>(?:VC|-|\\+)*+)(?<desc>(?:MI|PR|BC|DR|BL|SH|TS|FZ)++)?(?<prec>(?:DZ|RA|SN|SG|IC|PL|GR|GS|UP|/)*+)(?<obsc>BR|FG|FU|VA|DU|SA|HZ|PY)?(?<other>PO|SQ|FC|SS|DS|NSW|/++)?(?<int2>[-+])?\\s++"
     );
 
     /**
@@ -182,22 +182,22 @@ public final class RegExprConst {
 
     /**
      * Beginning and End of Precipitation/Weather Phenomena.
-     *
+     * <p>
      * Supports both minute-only and full timestamp formats:
      * - RAB05 → Rain began at :05 (2-digit format)
      * - FZRAB1159E1240 → Freezing rain began 11:59, ended 12:40 (4-digit format)
      * - RAB15E30 → Rain began :15, ended :30
      * - -RAB05 → Light rain began :05
      * - +TSRAB20E45 → Heavy thunderstorm with rain began :20, ended :45
-     *
+     * <p>
      * - Begin time: (?<begint>\\d{2,4}) allows 2 OR 4 digits
      * - End time: (?<endt>\\d{2,4}) allows 2 OR 4 digits
      * - Added word boundary (?=\\s|$) to prevent over-matching
-     *
+     * <p>
      * Time parsing logic (in handler):
      * - 2 digits (05) → minute only (:05)
      * - 4 digits (1159) → hour and minute (11:59)
-     *
+     * <p>
      * Complexity is required to capture weather type and flexible begin/end time formats.
      */
     @SuppressWarnings("java:S5843") // Complex regex required for precipitation timing format
@@ -231,7 +231,7 @@ public final class RegExprConst {
      */
     public static final Pattern WIND_SHIFT_PATTERN = Pattern.compile(
             "^WSHFT (?<hour>\\d{2})?(?<min>\\d{2})(\\s+(?<front>FROPA))?\\s*"
-            
+
     );
 
     /**
@@ -243,7 +243,7 @@ public final class RegExprConst {
     public static final Pattern TWR_SFC_VIS_PATTERN = Pattern.compile(
             "^(?<type>TWR VIS|SFC VIS)\\s+(?<dist>\\d+\\s\\d/\\d|\\d{1,2}/\\d{1,2}|\\d{1,2})?\\s*"
     );
-    
+
     /**
      * Variable Prevailing Visibility (VIS_vnvn vnvnVvxvxvx vxvx). Variable
      * prevailing visibility shall be coded in the format VIS_vn vnvnvnVvxvx
@@ -258,7 +258,7 @@ public final class RegExprConst {
     public static final Pattern VPV_SV_VSL_PATTERN = Pattern.compile(
             "^(?<vis>VIS)\\s+(?<dir>([NSEW]([EW])?))?\\s*(?<dist1>\\d{1,2}/\\d{1,2}|\\d+\\s+\\d{1,2}/\\d{1,2}|\\d+)?(\\s*(?<add>V|RWY)\\s*(?<dist2>\\d{1,2}/\\d{1,2}|\\d+\\s+\\d{1,2}/\\d{1,2}|\\d+))?\\s*"
     );
-    
+
     /**
      * Lightning (Frequency_LTG(type)_[LOC]).
      * Example: "OCNL LTGICCG VC"
@@ -279,7 +279,7 @@ public final class RegExprConst {
      */
     @SuppressWarnings("java:S5843") // Complex regex required for cloud location format
     public static final Pattern TS_CLD_LOC_PATTERN = Pattern.compile(
-           "^(?<type>TS|CB|TCU|ACC|CBMAM|VIRGA)(?!\\d)\\s*(?<loc>OHD|VC|DSNT|DSIPTD|TOP|TR)?\\s*(?:(?<dir>[NSEW]{1,2})(?:-(?<dir2>[NSEW]{1,2}))?)?(?:\\s*MOV\\s*(?<dirm>[NSEW]{1,2}))?(?=\\s|$)"
+            "^(?<type>TS|CB|TCU|ACC|CBMAM|VIRGA)(?!\\d)\\s*(?<loc>OHD|VC|DSNT|DSIPTD|TOP|TR)?\\s*(?:(?<dir>[NSEW]{1,2})(?:-(?<dir2>[NSEW]{1,2}))?)?(?:\\s*MOV\\s*(?<dirm>[NSEW]{1,2}))?(?=\\s|$)"
     );
 
     /**
@@ -297,7 +297,7 @@ public final class RegExprConst {
     public static final Pattern ICING_PATTERN = Pattern.compile(
             "^(?<type>ICG)((?<typeic>IC)?(?<typeip>IP)?)\\s(?<extra>\\w{4}\\s\\w{2})\\s+"
     );
-    
+
     /**
      * 6-hour maximum and minimum temperature in tenths degrees C format; 1sTTT
      * and 2sTTT
@@ -368,7 +368,7 @@ public final class RegExprConst {
      * Sky Conditions FEW = 1 to 2 oktas; SCT (Scattered) = 3 to 4 oktas; BKN
      * (Broken) = 5 to 7 oktas; OVC (Overcast) = 8 oktas;
      * Examples AC8SC1, CI TR, MDT CU OHD-ALQDS
-     * Complexity is required to capture cloud type, coverage in oktas, and location    
+     * Complexity is required to capture cloud type, coverage in oktas, and location
      */
     @SuppressWarnings("java:S5843") // Complex regex required for okta cloud format
     public static final Pattern CLOUD_OKTA_PATTERN = Pattern.compile(
@@ -392,7 +392,7 @@ public final class RegExprConst {
      */
     public static final Pattern PRESS_Q_PATTERN = Pattern.compile(
             "^(?<pressq>QFE|QNH|QNE)(?:(?<pressmm>\\d{3,4})(?:/(?<pressmb>\\d{3,4}))?)?\\s+"
-);
+    );
 
     /**
      * Automated Maintenance Data RVRNO: RVR missing; PWINO: precipitation
@@ -420,7 +420,7 @@ public final class RegExprConst {
     public static final Pattern GROUP_BECMG_TEMPO_PROB_PATTERN = Pattern.compile(
             "^(?<group>BECMG|TEMPO|PROB\\d{2})\\s+(?<obs>.+?)(?=\\s*$)"
     );
-    
+
     /**
      * Group - FM - From
      * Example: "FM121600"
@@ -505,7 +505,7 @@ public final class RegExprConst {
     /**
      * Hail size (GR followed by size in inches).
      * Format: GR 1/2, GR 3/4, GR 1, GR 1 3/4
-     *
+     * <p>
      * Examples:
      * - "GR 1/2" → 0.5 inch hail
      * - "GR 1 3/4" → 1.75 inch hail
@@ -518,7 +518,7 @@ public final class RegExprConst {
     /**
      * Variable Ceiling (CIG minVmax).
      * Ceiling varies between minimum and maximum heights in hundreds of feet.
-     *
+     * <p>
      * Examples:
      * - "CIG 005V010" → Ceiling 500-1000 feet
      * - "CIG 020V035" → Ceiling 2000-3500 feet
@@ -532,12 +532,12 @@ public final class RegExprConst {
      * Ceiling Height at Second Site (CIG height [LOC]).
      * Ceiling at a specific location (usually runway).
      * Height is in hundreds of feet, location is optional.
-     *
+     * <p>
      * Examples:
      * - "CIG 002 RY11" → Ceiling 200 ft at runway 11
      * - "CIG 005 RWY06" → Ceiling 500 ft at runway 06
      * - "CIG 010" → Ceiling 1000 ft (no location)
-     *
+     * <p>
      * NOTE: This pattern must be checked AFTER VARIABLE_CEILING_PATTERN
      * to avoid conflicts (variable ceiling has "V" separator).
      */
@@ -549,16 +549,16 @@ public final class RegExprConst {
     /**
      * Obscuration Layer ([Coverage] [Phenomenon] [Height]).
      * Represents obscuration like fog, mist, smoke at a specific height.
-     *
+     * <p>
      * Examples:
      * - "FEW FG 000" → Few fog at ground level
      * - "SCT FU 010" → Scattered smoke at 1000 feet
      * - "BKN BR 005" → Broken mist at 500 feet
-     *
+     * <p>
      * Coverage: FEW, SCT, BKN, OVC
      * Phenomenon: FG, BR, FU, HZ, DU, SA, VA, PY
      * Height: 3 digits (hundreds of feet)
-     *
+     * <p>
      * NOTE: Spaces distinguish this from SKY_CONDITION_PATTERN which has no spaces.
      */
     public static final Pattern OBSCURATION_PATTERN = Pattern.compile(

--- a/noakweather-platform/weather-processing/src/test/java/weather/processing/parser/common/WeatherParserTest.java
+++ b/noakweather-platform/weather-processing/src/test/java/weather/processing/parser/common/WeatherParserTest.java
@@ -23,45 +23,39 @@ import weather.model.NoaaWeatherData;
 import java.time.Instant;
 
 import static org.junit.jupiter.api.Assertions.*;
-/**
- *
- * @author bdeveloper
- */
-
-
 
 /**
  * Tests for WeatherParser interface.
  * Uses a concrete mock implementation to verify interface contract.
- * 
+ *
  * @author bclasky1539
  *
  */
 class WeatherParserTest {
-    
+
     /**
      * Mock implementation of WeatherParser for testing.
      */
     private static class MockWeatherParser implements WeatherParser<NoaaWeatherData> {
-        
+
         private final boolean shouldSucceed;
         private final String expectedPrefix;
-        
+
         public MockWeatherParser(boolean shouldSucceed, String expectedPrefix) {
             this.shouldSucceed = shouldSucceed;
             this.expectedPrefix = expectedPrefix;
         }
-        
+
         @Override
         public ParseResult<NoaaWeatherData> parse(String rawData) {
             if (rawData == null || rawData.trim().isEmpty()) {
                 return ParseResult.failure("Data cannot be null or empty");
             }
-            
+
             if (!canParse(rawData)) {
                 return ParseResult.failure("Cannot parse this data format");
             }
-            
+
             if (shouldSucceed) {
                 NoaaWeatherData data = new NoaaWeatherData("TEST", Instant.now(), "MOCK");
                 data.setRawData(rawData);
@@ -70,208 +64,208 @@ class WeatherParserTest {
                 return ParseResult.failure("Mock parser configured to fail");
             }
         }
-        
+
         @Override
         public boolean canParse(String rawData) {
             return rawData != null && rawData.startsWith(expectedPrefix);
         }
-        
+
         @Override
         public String getSourceType() {
             return "MOCK_PARSER";
         }
     }
-    
+
     @Test
     @DisplayName("Should parse data successfully when implementation succeeds")
     void testParseSuccess() {
         WeatherParser<NoaaWeatherData> parser = new MockWeatherParser(true, "TEST");
-        
+
         ParseResult<NoaaWeatherData> result = parser.parse("TEST DATA");
-        
+
         assertTrue(result.isSuccess());
         assertTrue(result.getData().isPresent());
         assertEquals("TEST", result.getData().get().getStationId());
     }
-    
+
     @Test
     @DisplayName("Should fail to parse when implementation fails")
     void testParseFailure() {
         WeatherParser<NoaaWeatherData> parser = new MockWeatherParser(false, "TEST");
-        
+
         ParseResult<NoaaWeatherData> result = parser.parse("TEST DATA");
-        
+
         assertTrue(result.isFailure());
         assertEquals("Mock parser configured to fail", result.getErrorMessage());
     }
-    
+
     @Test
     @DisplayName("Should validate parseable data correctly")
     void testCanParse() {
         WeatherParser<NoaaWeatherData> parser = new MockWeatherParser(true, "VALID");
-        
+
         assertTrue(parser.canParse("VALID DATA"));
         assertFalse(parser.canParse("INVALID DATA"));
         assertFalse(parser.canParse(null));
     }
-    
+
     @Test
     @DisplayName("Should return source type identifier")
     void testGetSourceType() {
         WeatherParser<NoaaWeatherData> parser = new MockWeatherParser(true, "TEST");
-        
+
         assertEquals("MOCK_PARSER", parser.getSourceType());
     }
-    
+
     @Test
     @DisplayName("Should handle null input gracefully")
     void testParseNull() {
         WeatherParser<NoaaWeatherData> parser = new MockWeatherParser(true, "TEST");
-        
+
         ParseResult<NoaaWeatherData> result = parser.parse(null);
-        
+
         assertTrue(result.isFailure());
         assertEquals("Data cannot be null or empty", result.getErrorMessage());
     }
-    
+
     @Test
     @DisplayName("Should handle empty input gracefully")
     void testParseEmpty() {
         WeatherParser<NoaaWeatherData> parser = new MockWeatherParser(true, "TEST");
-        
+
         ParseResult<NoaaWeatherData> result = parser.parse("");
-        
+
         assertTrue(result.isFailure());
         assertEquals("Data cannot be null or empty", result.getErrorMessage());
     }
-    
+
     @Test
     @DisplayName("Should handle whitespace input gracefully")
     void testParseWhitespace() {
         WeatherParser<NoaaWeatherData> parser = new MockWeatherParser(true, "TEST");
-        
+
         ParseResult<NoaaWeatherData> result = parser.parse("   ");
-        
+
         assertTrue(result.isFailure());
         assertEquals("Data cannot be null or empty", result.getErrorMessage());
     }
-    
+
     @Test
     @DisplayName("Should fail when data format is not supported")
     void testParseUnsupportedFormat() {
         WeatherParser<NoaaWeatherData> parser = new MockWeatherParser(true, "EXPECTED");
-        
+
         ParseResult<NoaaWeatherData> result = parser.parse("UNEXPECTED DATA");
-        
+
         assertTrue(result.isFailure());
         assertEquals("Cannot parse this data format", result.getErrorMessage());
     }
-    
+
     @Test
     @DisplayName("Should work with different parser configurations")
     void testDifferentConfigurations() {
         WeatherParser<NoaaWeatherData> parser1 = new MockWeatherParser(true, "TYPE1");
         WeatherParser<NoaaWeatherData> parser2 = new MockWeatherParser(true, "TYPE2");
-        
+
         assertTrue(parser1.canParse("TYPE1 data"));
         assertFalse(parser1.canParse("TYPE2 data"));
-        
+
         assertFalse(parser2.canParse("TYPE1 data"));
         assertTrue(parser2.canParse("TYPE2 data"));
     }
-    
+
     @Test
     @DisplayName("Should store raw data in parsed result")
     void testRawDataPreserved() {
         WeatherParser<NoaaWeatherData> parser = new MockWeatherParser(true, "TEST");
         String rawData = "TEST SAMPLE DATA";
-        
+
         ParseResult<NoaaWeatherData> result = parser.parse(rawData);
-        
+
         assertTrue(result.isSuccess());
         assertEquals(rawData, result.getData().get().getRawData());
     }
-    
+
     @Test
     @DisplayName("Should be usable in polymorphic context")
     void testPolymorphicUsage() {
         // Create array of different parser types
         WeatherParser<?>[] parsers = new WeatherParser[]{
-            new MockWeatherParser(true, "TYPE1"),
-            new MockWeatherParser(true, "TYPE2"),
-            new MockWeatherParser(true, "TYPE3")
+                new MockWeatherParser(true, "TYPE1"),
+                new MockWeatherParser(true, "TYPE2"),
+                new MockWeatherParser(true, "TYPE3")
         };
-        
+
         // Verify all implement the interface correctly
         for (WeatherParser<?> parser : parsers) {
             assertNotNull(parser.getSourceType());
             assertNotNull(parser.parse("TYPE1 data")); // Will succeed or fail based on type
         }
     }
-    
+
     @Test
     @DisplayName("Should support parser chaining logic")
     void testParserChaining() {
         WeatherParser<NoaaWeatherData> parser1 = new MockWeatherParser(true, "FORMAT1");
         WeatherParser<NoaaWeatherData> parser2 = new MockWeatherParser(true, "FORMAT2");
-        
+
         String data1 = "FORMAT1 data";
         String data2 = "FORMAT2 data";
-        
+
         // Simulate trying parsers in sequence
-        ParseResult<NoaaWeatherData> result1 = parser1.canParse(data1) 
-            ? parser1.parse(data1) 
-            : parser2.parse(data1);
-        
-        ParseResult<NoaaWeatherData> result2 = parser1.canParse(data2) 
-            ? parser1.parse(data2) 
-            : parser2.parse(data2);
-        
+        ParseResult<NoaaWeatherData> result1 = parser1.canParse(data1)
+                ? parser1.parse(data1)
+                : parser2.parse(data1);
+
+        ParseResult<NoaaWeatherData> result2 = parser1.canParse(data2)
+                ? parser1.parse(data2)
+                : parser2.parse(data2);
+
         assertTrue(result1.isSuccess());
         assertTrue(result2.isSuccess());
     }
-    
+
     @Test
     @DisplayName("Should maintain consistent source type")
     void testSourceTypeConsistency() {
         WeatherParser<NoaaWeatherData> parser = new MockWeatherParser(true, "TEST");
-        
+
         String type1 = parser.getSourceType();
         String type2 = parser.getSourceType();
-        
+
         assertEquals(type1, type2);
         assertEquals("MOCK_PARSER", type1);
     }
-    
+
     @Test
     @DisplayName("Should work with case-sensitive prefixes")
     void testCaseSensitivity() {
         WeatherParser<NoaaWeatherData> parser = new MockWeatherParser(true, "TEST");
-        
+
         assertTrue(parser.canParse("TEST data"));
         assertFalse(parser.canParse("test data")); // lowercase
         assertFalse(parser.canParse("Test data")); // mixed case
     }
-    
+
     @Test
     @DisplayName("Should handle very long input data")
     void testLongInputData() {
         WeatherParser<NoaaWeatherData> parser = new MockWeatherParser(true, "LONG");
         String longData = "LONG" + "A".repeat(10000);
-        
+
         ParseResult<NoaaWeatherData> result = parser.parse(longData);
-        
+
         assertTrue(result.isSuccess());
         assertEquals(longData, result.getData().get().getRawData());
     }
-    
+
     @Test
     @DisplayName("Should work with minimal valid input")
     void testMinimalInput() {
         WeatherParser<NoaaWeatherData> parser = new MockWeatherParser(true, "X");
-        
+
         ParseResult<NoaaWeatherData> result = parser.parse("X");
-        
+
         assertTrue(result.isSuccess());
         assertEquals("X", result.getData().get().getRawData());
     }

--- a/noakweather-platform/weather-storage/pom.xml
+++ b/noakweather-platform/weather-storage/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.17.0-SNAPSHOT</version>
+        <version>1.17.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-storage</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>weather</groupId>
     <artifactId>noakweather-engineering-pipeline</artifactId>
-    <version>1.17.0-SNAPSHOT</version>
+    <version>1.17.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>NoakWeather Engineering Pipeline Root</name>


### PR DESCRIPTION
Fixes the maintainability and reliability issues flagged by SonarCloud following the merge of the Bronze-to-Silver Glue ETL work (1.17.0):

- Implicit time zone in timestamp generation (java:S8688) S3UploadService and SpeedLayerProcessor used LocalDateTime.now() without a zone, implicitly relying on the JVM's default system time zone. Both now use LocalDateTime.now(ZoneOffset.UTC), matching the platform's UTC-based timestamp convention.

- Duplicated null/empty validation logic S3UploadService had the same 9-line null/empty check pattern duplicated across methods for source, rawData, and stationId. Extracted into a shared requireNonEmpty(String value, String paramName) helper, applied consistently across all three parameters at both uploadRawData() and uploadRawDataWithPartitioning().

- Non-linear regex backtracking risk (java:S8786) RegExprConst.PRESENT_WEATHER_PATTERN chained multiple optional, alternation-based repeating groups - a shape that can exhibit catastrophic backtracking on malformed input. Rewrote the repeating groups with possessive quantifiers and non-capturing groups to eliminate the backtracking ambiguity while preserving identical matching behavior for valid input. NoaaMetarParser's simple \s+RMK\s+ split pattern was flagged by the same rule but assessed as a false positive (no alternation, no nested quantifiers); suppressed with @SuppressWarnings("java:S8786").

- Dangling Javadoc comment (java:S8491) Removed an orphaned Javadoc block in WeatherParserTest that was not properly attached to the class declaration.

Bumped noakweather-platform and all submodules from 1.17.0-SNAPSHOT to 1.17.1-SNAPSHOT (patch release; noakweather-legacy remains at 0.0.5, untouched). Updated CHANGELOG.md accordingly.

Testing: full suite passing (0 failures, 0 errors) after fixes. The requireNonEmpty extraction initially broke 8 S3UploadServiceTest cases because only the source parameter was wired to the new helper, omitting the rawData and stationId checks that existed in the original duplicated blocks - caught by wetht.sh and corrected before this commit.