### PR TITLE
Convert anonymous classes to lambdas and Arrays.asList() to List.of()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Version 1.17.2-SNAPSHOT - August 28, 2026
+
+#### Additional SonarCloud Fixes - Modern Java Idioms
+
+**Fixed:**
+- **Anonymous classes on functional interfaces** (weather-common) (java:S9357)
+  - `WeatherValidatorTest` used anonymous inner class implementations of
+    the single-method `WeatherValidator<T>` functional interface in two
+    places; converted both to lambda expressions
+  - Flagged by a SonarCloud rule not previously present in the rule set
+    when this test file was last modified; retroactively surfaced once
+    a full analysis ran again after the `SONAR_TOKEN` fix earlier in
+    this cleanup effort
+
+- **`Arrays.asList()` with a single argument** (weather-common)
+  - `WeatherValidatorTest` used `Arrays.asList("...")` with a single
+    string literal argument in 5 places to construct validation error
+    lists
+  - Replaced with `List.of("...")`, the more idiomatic Java 9+
+    construct for small immutable lists; `Arrays.asList()` returns a
+    fixed-size but still partially-mutable (via `set()`) list, whereas
+    `List.of()` is fully immutable and disallows `null` elements,
+    better matching the intended use as a fixed validation-error list
+
+**Testing:**
+- Full test suite passing (0 failures, 0 errors) after all 7 changes,
+  confirming no downstream code depended on the mutable/nullable
+  semantics of the original `Arrays.asList()` calls or anonymous class
+  instances
+
 ### Version 1.17.1-SNAPSHOT - August 28, 2026
 
 #### SonarCloud Maintainability and Reliability Fixes

--- a/noakweather-platform/pom.xml
+++ b/noakweather-platform/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>weather</groupId>
     <artifactId>noakweather-platform</artifactId>
-    <version>1.17.1-SNAPSHOT</version>
+    <version>1.17.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>NoakWeather Engineering Pipeline</name>

--- a/noakweather-platform/weather-analytics/pom.xml
+++ b/noakweather-platform/weather-analytics/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.17.1-SNAPSHOT</version>
+        <version>1.17.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-analytics</artifactId>

--- a/noakweather-platform/weather-common/pom.xml
+++ b/noakweather-platform/weather-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.17.1-SNAPSHOT</version>
+        <version>1.17.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-common</artifactId>

--- a/noakweather-platform/weather-common/src/test/java/weather/service/WeatherValidatorTest.java
+++ b/noakweather-platform/weather-common/src/test/java/weather/service/WeatherValidatorTest.java
@@ -22,17 +22,17 @@ import weather.model.WeatherData;
 import weather.model.TestWeatherData;
 
 import java.time.Instant;
-import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for WeatherValidator interface, specifically the default methods.
- * 
+ *
  * @author bclasky1539
  */
 class WeatherValidatorTest {
-    
+
     /**
      * Test implementation that returns a successful validation
      */
@@ -42,27 +42,27 @@ class WeatherValidatorTest {
             return ValidationResult.success();
         }
     }
-    
+
     /**
      * Test implementation that returns validation with warnings
      */
     private static class WarningValidator implements WeatherValidator<WeatherData> {
         @Override
         public ValidationResult validate(WeatherData data) {
-            return ValidationResult.withWarnings(Arrays.asList("Test warning"));
+            return ValidationResult.withWarnings(List.of("Test warning"));
         }
     }
-    
+
     /**
      * Test implementation that returns validation failure
      */
     private static class FailureValidator implements WeatherValidator<WeatherData> {
         @Override
         public ValidationResult validate(WeatherData data) {
-            return ValidationResult.failure(Arrays.asList("Test error"));
+            return ValidationResult.failure(List.of("Test error"));
         }
     }
-    
+
     /**
      * Test implementation that returns failure with warnings
      */
@@ -70,95 +70,88 @@ class WeatherValidatorTest {
         @Override
         public ValidationResult validate(WeatherData data) {
             return ValidationResult.failure(
-                Arrays.asList("Test error"),
-                Arrays.asList("Test warning")
+                    List.of("Test error"),
+                    List.of("Test warning")
             );
         }
     }
-    
+
     @Test
     @DisplayName("Should return true when validation succeeds")
     void testIsValid_Success() {
         WeatherValidator<WeatherData> validator = new SuccessValidator();
         TestWeatherData data = new TestWeatherData();
-        
+
         boolean isValid = validator.isValid(data);
-        
+
         assertTrue(isValid, "isValid should return true for successful validation");
     }
-    
+
     @Test
     @DisplayName("Should return true when validation has only warnings")
     void testIsValid_WithWarnings() {
         WeatherValidator<WeatherData> validator = new WarningValidator();
         TestWeatherData data = new TestWeatherData();
-        
+
         boolean isValid = validator.isValid(data);
-        
+
         assertTrue(isValid, "isValid should return true when only warnings exist");
     }
-    
+
     @Test
     @DisplayName("Should return false when validation fails")
     void testIsValid_Failure() {
         WeatherValidator<WeatherData> validator = new FailureValidator();
         TestWeatherData data = new TestWeatherData();
-        
+
         boolean isValid = validator.isValid(data);
-        
+
         assertFalse(isValid, "isValid should return false when validation fails");
     }
-    
+
     @Test
     @DisplayName("Should return false when validation fails with warnings")
     void testIsValid_FailureWithWarnings() {
         WeatherValidator<WeatherData> validator = new FailureWithWarningsValidator();
         TestWeatherData data = new TestWeatherData();
-        
+
         boolean isValid = validator.isValid(data);
-        
+
         assertFalse(isValid, "isValid should return false when validation fails even with warnings");
     }
-    
+
     @Test
     @DisplayName("Should call validate method when isValid is called")
     void testIsValidCallsValidate() {
         // Track if validate was called
         final boolean[] validateCalled = {false};
-        
-        WeatherValidator<WeatherData> validator = new WeatherValidator<WeatherData>() {
-            @Override
-            public ValidationResult validate(WeatherData data) {
-                validateCalled[0] = true;
-                return ValidationResult.success();
-            }
+
+        WeatherValidator<WeatherData> validator = data -> {
+            validateCalled[0] = true;
+            return ValidationResult.success();
         };
-        
+
         TestWeatherData data = new TestWeatherData();
         validator.isValid(data);
-        
+
         assertTrue(validateCalled[0], "isValid should call validate() method");
     }
-    
+
     @Test
     @DisplayName("Should work with different WeatherData subclasses")
     void testWithDifferentWeatherDataTypes() {
-        WeatherValidator<TestWeatherData> validator = new WeatherValidator<TestWeatherData>() {
-            @Override
-            public ValidationResult validate(TestWeatherData data) {
-                // Simple validation: check if observation time is set
-                if (data.getObservationTime() == null) {
-                    return ValidationResult.failure(Arrays.asList("Observation time required"));
-                }
-                return ValidationResult.success();
+        WeatherValidator<TestWeatherData> validator = data -> {
+            if (data.getObservationTime() == null) {
+                return ValidationResult.failure(List.of("Observation time required"));
             }
+            return ValidationResult.success();
         };
-        
+
         // Test with observation time
         TestWeatherData dataWithTime = new TestWeatherData();
         dataWithTime.setObservationTime(Instant.now());
         assertTrue(validator.isValid(dataWithTime));
-        
+
         // Test without observation time
         TestWeatherData dataWithoutTime = new TestWeatherData();
         dataWithoutTime.setObservationTime(null);

--- a/noakweather-platform/weather-infrastructure/pom.xml
+++ b/noakweather-platform/weather-infrastructure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.17.1-SNAPSHOT</version>
+        <version>1.17.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-infrastructure</artifactId>

--- a/noakweather-platform/weather-ingestion/pom.xml
+++ b/noakweather-platform/weather-ingestion/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.17.1-SNAPSHOT</version>
+        <version>1.17.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-ingestion</artifactId>

--- a/noakweather-platform/weather-processing/pom.xml
+++ b/noakweather-platform/weather-processing/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.17.1-SNAPSHOT</version>
+        <version>1.17.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-processing</artifactId>

--- a/noakweather-platform/weather-storage/pom.xml
+++ b/noakweather-platform/weather-storage/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.17.1-SNAPSHOT</version>
+        <version>1.17.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-storage</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>weather</groupId>
     <artifactId>noakweather-engineering-pipeline</artifactId>
-    <version>1.17.1-SNAPSHOT</version>
+    <version>1.17.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>NoakWeather Engineering Pipeline Root</name>


### PR DESCRIPTION
Additional SonarCloud fixes discovered after the 1.17.1-SNAPSHOT maintainability/reliability cleanup, found on main post-merge:

- Anonymous classes on functional interfaces (java:S9357) WeatherValidatorTest used anonymous inner class implementations of the single-method WeatherValidator<T> functional interface in two places. Converted both to lambda expressions. This rule was not previously present in SonarCloud's rule set when the file was last modified 9 months ago; it retroactively surfaced once a full analysis ran again after the SONAR_TOKEN fix earlier in this session.

- Arrays.asList() with a single argument WeatherValidatorTest used Arrays.asList("...") with a single string literal argument in 5 places to construct validation error lists. Replaced with List.of("..."), the more idiomatic Java 9+ construct for small immutable lists. Arrays.asList() returns a fixed-size but still partially-mutable (via set()) list, whereas List.of() is fully immutable and disallows null elements, better matching the intended use as a fixed validation-error list.

Bumped noakweather-platform and all submodules from 1.17.1-SNAPSHOT to 1.17.2-SNAPSHOT (patch release; noakweather-legacy remains at 0.0.5, untouched). Updated CHANGELOG.md accordingly.

Testing: full suite passing (0 failures, 0 errors) after all 7 changes, confirming no downstream code depended on the mutable or nullable semantics of the original Arrays.asList() calls or anonymous class instances.