### PR TITLE
Add .gitattributes to fix missing SQL language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Normalize line endings to LF
+* text=auto
+
+# SQL files are being silently excluded from GitHub's language
+# detection (0 bytes reported via the GitHub API's /languages
+# endpoint despite 324 lines of real DDL in sql/). Explicit override
+# forces Linguist to recognize and count them.
+*.sql linguist-language=SQL linguist-detectable=true
+
+# Explicit hints for the other languages already detected correctly;
+# makes intent self-documenting and future-proofs against edge cases
+*.java linguist-language=Java
+*.py linguist-language=Python
+*.sh linguist-language=Shell


### PR DESCRIPTION
GitHub's language stats (via the /languages API) showed only Java, Python, and Shell - SQL was completely absent despite 324 lines of real DDL across sql/bronze/create_bronze_metar_noaa.sql and sql/silver/create_silver_observations.sql. Python and Shell were being detected correctly but bucketed into the 'Other 0.9%' display segment simply due to their small size relative to Java (~2.85MB); SQL's absence was a separate, genuine Linguist detection gap.

Adds:
- '* text=auto' for consistent LF line-ending normalization
- 'linguist-detectable=true' override on *.sql to force recognition
- Explicit linguist-language hints for .java/.py/.sh, self- documenting intent even though those three are already detected correctly

Note: GitHub's language bar only recalculates on new pushes to the default branch, so the displayed percentages won't update until this merges to main and the next Linguist analysis pass runs.