### PR TITLE
Add worldwide METAR UAT ingestion and validation tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Version 1.19.0-SNAPSHOT - September 2, 2026
+
+#### Worldwide METAR UAT Sweep and Tooling
+
+**Added:**
+- **`wethuat_metar_ingest.sh`** - UAT ingestion sweep script (repository root)
+  - Ingests METAR data for a curated, diverse set of worldwide stations
+    (spanning unit systems, hemispheres, climates, and reporting conventions),
+    then validates each station's resulting Bronze layer output
+  - Tracks ingestion and validation results separately, logging a
+    complete summary at the end
+  - Includes an initial check confirming `python3`/`boto3` availability
+    before starting, to fail fast with a clear diagnostic rather than
+    discovering a missing dependency after every station
+
+- **`glue-jobs/tools/analyze_bronze_station.py`** - Bronze layer validation tool
+  - Standalone local CLI tool (not deployed to AWS Glue) verifying a single
+    station/date's raw-data and speed-layer S3 output for structural
+    correctness: file presence, valid JSON, **duplicate JSON keys** (a direct
+    regression check against the historical Jackson serialization bug fixed
+    earlier), required fields, `dataType`/`stationId` match, and raw/JSON
+    content consistency
+  - Flags unparsed content (`unparsedMainBody`, `remarks.freeText`) as a
+    WARNING rather than a failure, since unrecognized real-world content is
+    exactly the signal this UAT process exists to surface
+  - Reuses `glue-jobs/requirements.txt` (boto3) rather than introducing a
+    separate dependency surface
+
+**UAT Findings:**
+- First full sweep (79 stations): 66 PASS, 13 WARN, 0 FAIL
+- Findings triaged into 11 GitHub issues (#53-#63), tracked via a new
+  `METAR UAT Remediation` Kanban project board and `UAT Round 1` milestone,
+  covering:
+  - A structural bug where remarks parsing silently corrupts downstream
+    content after an unmatched token, affecting even well-tested existing
+    features (Sea Level Pressure, precise temperature) on both US and
+    Canadian stations (#53)
+  - Missing-data placeholders (`//////`) incorrectly parsed as present
+    weather phenomena rather than recognized as absent data (#54)
+  - METAR trend forecast groups (TEMPO/BECMG/FM/PROB) not yet parsed in
+    the main body, beyond the existing NOSIG support (#55)
+  - Eight country/region-specific unsupported remark formats: secondary
+    altimeter repetition (Philippines/Taiwan), Canadian chained cloud-type
+    qualifiers and density altitude, Mexican supplementary groups, Jamaican
+    ceilometer remarks, Caribbean directional vicinity-weather remarks,
+    South American precipitation groups, and Norwegian/Arctic
+    wind-at-altitude remarks (#56, #57, #58-#62)
+  - Observation year currently derived from system clock rather than
+    parsed from NOAA's source data header line, a latent year-boundary
+    risk (#63)
+
+**Fixed:**
+- `glue-jobs/README.md`: corrected the documented Silver layer output path,
+  which still referenced the pre-fix double-partitioned structure
+  (`silver/observations/noaa/{year}/{month}/{day}/`) rather than the actual
+  Hive-style partitioned path; corrected the example Glue job creation
+  command's `--role` from a generic placeholder to the actual IAM role name;
+  removed leftover scratch text; documented the new `tools/` subdirectory
+
 ### Version 1.18.0-SNAPSHOT - August 29, 2026
 
 #### Build Tooling and Documentation Cleanup

--- a/glue-jobs/README.md
+++ b/glue-jobs/README.md
@@ -20,7 +20,34 @@ Transforms raw NOAA METAR observations from Bronze layer (nested JSON) to Silver
 **Schedule:** Daily at 2 AM UTC (via Step Functions)
 
 **Input:** `s3://noakweather-data/bronze/speed-layer/noaa/metar/{year}/{month}/{day}/`
-**Output:** `s3://noakweather-data/silver/observations/noaa/{year}/{month}/{day}/`
+<br>**Output:** `s3://noakweather-data/silver/observations/` (Hive-style partitioned by `data_source`, `year`, `month`, `day`)
+
+## Tools
+
+### tools/analyze_bronze_station.py
+Standalone local CLI tool (not deployed to AWS Glue) for validating Bronze-layer
+ingestion output during UAT testing. Checks a single station/date's raw-data
+`.txt` and speed-layer `.json` files in S3 for structural correctness — missing
+files, malformed JSON, duplicate JSON keys (a regression check for a historical
+Jackson serialization bug), missing required fields, and unparsed content in
+`unparsedMainBody`/`remarks.freeText`.
+
+**Usage:**
+```bash
+python3 glue-jobs/tools/analyze_bronze_station.py STATION DATE [--bucket BUCKET]
+# Example:
+python3 glue-jobs/tools/analyze_bronze_station.py KATL 2026-09-01
+```
+
+**Exit codes:** `0` = PASS, `2` = WARN (noteworthy but not a bug, e.g. unrecognized
+remarks content), `1` = FAIL (structural problem)
+
+**Dependencies:** Uses the same `requirements.txt` as the Glue jobs above (boto3).
+Run inside the `glue_env` conda environment, or any environment with `boto3`
+installed.
+
+**Typically invoked via** `./wethuat_metar_ingest.sh` at the repository root,
+which runs it automatically after each station's ingestion during a UAT sweep.
 
 ## Deployment
 
@@ -28,7 +55,7 @@ Deploy to AWS Glue using AWS Console or CLI:
 ```bash
 aws glue create-job \
   --name bronze-to-silver-metar \
-  --role GlueServiceRole \
+  --role AWSGlueServiceRole-NoakWeather \
   --command "Name=glueetl,ScriptLocation=s3://noakweather-glue-scripts/bronze_to_silver_metar.py" \
   --default-arguments '{"--source_date":"2026-02-10"}' \
   --glue-version "4.0" \
@@ -51,4 +78,4 @@ docker run -it -v $(pwd):/home/glue_user/workspace/ \
 - `silver_to_gold_ml_features.py` - ML feature store
 
 # Save the Glue script
-# (Use the script I provided earlier)
+

--- a/glue-jobs/tools/analyze_bronze_station.py
+++ b/glue-jobs/tools/analyze_bronze_station.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""
+analyze_bronze_station.py
+
+Location: glue-jobs/tools/analyze_bronze_station.py
+
+UAT validation tool: verifies that a single station's Bronze-layer output
+(both raw-data/*.txt and speed-layer/*.json) exists in S3 and passes a set
+of structural sanity checks, for a given ingestion date.
+
+This is a standalone local CLI tool - unlike the scripts in glue-jobs/,
+it does not run inside AWS Glue's PySpark runtime and is never uploaded
+to S3. It lives in glue-jobs/tools/ (rather than glue-jobs/ directly) to
+keep that distinction clear, while still reusing glue-jobs/requirements.txt
+for its one dependency (boto3), since the existing glue_env conda
+environment already has it installed.
+
+Usage:
+    python3 glue-jobs/tools/analyze_bronze_station.py STATION DATE [--bucket BUCKET]
+
+    STATION  ICAO station code, e.g. KATL
+    DATE     Ingestion date (UTC) in YYYY-MM-DD format
+
+Exit codes:
+    0  PASS  - no issues found
+    1  FAIL  - a structural/content problem was found (missing file,
+               malformed JSON, duplicate keys, missing required fields,
+               station ID mismatch, raw/JSON text mismatch)
+    2  WARN  - ingestion succeeded and structure is valid, but something
+               noteworthy was found that does not indicate a bug (e.g.
+               unparsed tokens in the main body - this is expected/useful
+               UAT signal, not a failure)
+
+Requires: boto3 (see glue-jobs/requirements.txt), with AWS credentials
+already configured (same credential chain used by the AWS CLI).
+"""
+
+import sys
+import json
+import argparse
+from datetime import datetime
+
+import importlib.util
+
+if importlib.util.find_spec("boto3") is None:
+    print("ERROR: boto3 is required. Install with: pip install boto3 --break-system-packages")
+    sys.exit(1)
+
+import boto3
+from botocore.exceptions import ClientError
+
+DEFAULT_BUCKET = "noakweather-data"
+RAW_DATA_PREFIX_TEMPLATE = "bronze/raw-data/noaa/metar/{year}/{month}/{day}/"
+SPEED_LAYER_PREFIX_TEMPLATE = "bronze/speed-layer/noaa/metar/{year}/{month}/{day}/"
+
+REQUIRED_TOP_LEVEL_FIELDS = [
+    "id", "dataType", "stationId", "observationTime", "ingestionTime",
+    "rawText", "conditions",
+]
+REQUIRED_CONDITIONS_FIELDS = ["wind", "visibility", "temperature", "pressure"]
+
+
+class ValidationReport:
+    """Collects PASS/WARN/FAIL findings for a single station's validation run."""
+
+    def __init__(self, station, date_str):
+        self.station = station
+        self.date_str = date_str
+        self.failures = []
+        self.warnings = []
+        self.info = []
+
+    def fail(self, message):
+        self.failures.append(message)
+
+    def warn(self, message):
+        self.warnings.append(message)
+
+    def note(self, message):
+        self.info.append(message)
+
+    def result(self):
+        if self.failures:
+            return "FAIL"
+        if self.warnings:
+            return "WARN"
+        return "PASS"
+
+    def exit_code(self):
+        return {"PASS": 0, "WARN": 2, "FAIL": 1}[self.result()]
+
+    def print_report(self):
+        print(f"=== UAT Validation: {self.station} ({self.date_str}) ===")
+        for line in self.info:
+            print(f"  INFO: {line}")
+        for line in self.warnings:
+            print(f"  WARNING: {line}")
+        for line in self.failures:
+            print(f"  FAILURE: {line}")
+        print(f"UAT_RESULT: {self.result()}")
+
+
+def find_latest_object(s3, bucket, prefix, station):
+    """Find the most recently modified object under prefix whose filename
+    starts with '{station}_'. Returns (key, match_count); key is None if
+    nothing matched."""
+    paginator = s3.get_paginator("list_objects_v2")
+    matches = []
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            filename = obj["Key"].rsplit("/", 1)[-1]
+            if filename.startswith(f"{station}_"):
+                matches.append(obj)
+    if not matches:
+        return None, 0
+    matches.sort(key=lambda o: o["LastModified"], reverse=True)
+    return matches[0]["Key"], len(matches)
+
+
+def duplicate_key_pairs_hook(duplicates_log):
+    """Returns a json.loads object_pairs_hook that records any duplicate
+    keys found within a single JSON object, at any nesting level. This is
+    a direct regression check for the Bronze layer duplicate-fields bug
+    fixed earlier (Jackson serializing both nested conditions.* and
+    flattened top-level convenience-getter properties). json.loads()
+    would otherwise silently keep only the last value for a duplicate
+    key, hiding the problem the same way it went undetected originally."""
+    def hook(pairs):
+        seen = set()
+        for key, _ in pairs:
+            if key in seen:
+                duplicates_log.append(key)
+            seen.add(key)
+        return dict(pairs)
+    return hook
+
+
+def get_nested(data, *path):
+    """Safely walk a nested dict, returning None if any level is missing."""
+    current = data
+    for key in path:
+        if not isinstance(current, dict) or key not in current:
+            return None
+        current = current[key]
+    return current
+
+
+def validate_station(s3, bucket, station, date_str):
+    report = ValidationReport(station, date_str)
+    year, month, day = date_str.split("-")
+
+    raw_prefix = RAW_DATA_PREFIX_TEMPLATE.format(year=year, month=month, day=day)
+    json_prefix = SPEED_LAYER_PREFIX_TEMPLATE.format(year=year, month=month, day=day)
+
+    raw_key, raw_count = find_latest_object(s3, bucket, raw_prefix, station)
+    json_key, json_count = find_latest_object(s3, bucket, json_prefix, station)
+
+    if raw_key is None:
+        report.fail(f"No raw-data file found under s3://{bucket}/{raw_prefix}")
+    elif raw_count > 1:
+        report.note(f"{raw_count} raw-data files found for this date; validating most recent ({raw_key})")
+
+    if json_key is None:
+        report.fail(f"No speed-layer JSON file found under s3://{bucket}/{json_prefix}")
+    elif json_count > 1:
+        report.note(f"{json_count} speed-layer files found for this date; validating most recent ({json_key})")
+
+    if raw_key is None or json_key is None:
+        return report  # Can't do content checks without both files
+
+    try:
+        raw_obj = s3.get_object(Bucket=bucket, Key=raw_key)
+        raw_text = raw_obj["Body"].read().decode("utf-8")
+    except ClientError as e:
+        report.fail(f"Failed to download raw-data file: {e}")
+        return report
+
+    try:
+        json_obj = s3.get_object(Bucket=bucket, Key=json_key)
+        json_text = json_obj["Body"].read().decode("utf-8")
+    except ClientError as e:
+        report.fail(f"Failed to download speed-layer JSON file: {e}")
+        return report
+
+    duplicates_found = []
+    try:
+        data = json.loads(json_text, object_pairs_hook=duplicate_key_pairs_hook(duplicates_found))
+    except json.JSONDecodeError as e:
+        report.fail(f"speed-layer JSON is not valid JSON: {e}")
+        return report
+
+    if duplicates_found:
+        unique_dupes = sorted(set(duplicates_found))
+        report.fail(f"Duplicate JSON keys detected (Jackson serialization regression?): {unique_dupes}")
+
+    for field in REQUIRED_TOP_LEVEL_FIELDS:
+        if field not in data:
+            report.fail(f"Missing required top-level field: '{field}'")
+
+    if data.get("dataType") != "METAR":
+        report.fail(f"Expected dataType 'METAR', found '{data.get('dataType')}'")
+
+    if data.get("stationId") != station:
+        report.fail(f"Expected stationId '{station}', found '{data.get('stationId')}'")
+
+    obs_time = data.get("observationTime")
+    if not isinstance(obs_time, (int, float)):
+        report.fail(f"observationTime is missing or not numeric: {obs_time!r}")
+
+    raw_text_field = data.get("rawText")
+    if not raw_text_field:
+        report.fail("rawText field is missing or empty")
+    elif station not in raw_text_field[:20]:
+        report.warn(f"Station code '{station}' not found near start of rawText: {raw_text_field[:40]!r}")
+
+    if raw_text_field and raw_text.strip() != raw_text_field.strip():
+        report.fail(
+            "raw-data file content does not match speed-layer JSON's rawText field "
+            "(dual storage inconsistency)"
+        )
+
+    conditions = data.get("conditions")
+    if isinstance(conditions, dict):
+        for field in REQUIRED_CONDITIONS_FIELDS:
+            if field not in conditions:
+                report.fail(f"Missing required conditions field: 'conditions.{field}'")
+    # (missing 'conditions' itself is already caught by REQUIRED_TOP_LEVEL_FIELDS)
+
+    # Soft/warning-level checks - interesting UAT signal, not bugs
+    unparsed = data.get("unparsedMainBody")
+    if unparsed:
+        report.warn(f"Unparsed main body tokens found: {unparsed!r}")
+
+    remarks_free_text = get_nested(data, "remarks", "freeText")
+    if remarks_free_text:
+        report.warn(f"Unparsed remarks content found (remarks.freeText): {remarks_free_text!r}")
+
+    temp_celsius = get_nested(data, "conditions", "temperature", "celsius")
+    if temp_celsius is None:
+        report.warn("No temperature reported (conditions.temperature.celsius is null)")
+
+    pressure_value = get_nested(data, "conditions", "pressure", "value")
+    if pressure_value is None:
+        report.warn("No pressure reported (conditions.pressure.value is null)")
+
+    return report
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate a station's Bronze-layer UAT output")
+    parser.add_argument("station", help="ICAO station code, e.g. KATL")
+    parser.add_argument("date", help="Ingestion date (UTC), format YYYY-MM-DD")
+    parser.add_argument("--bucket", default=DEFAULT_BUCKET, help=f"S3 bucket (default: {DEFAULT_BUCKET})")
+    args = parser.parse_args()
+
+    try:
+        datetime.strptime(args.date, "%Y-%m-%d")
+    except ValueError:
+        print(f"ERROR: date must be in YYYY-MM-DD format, got '{args.date}'")
+        sys.exit(1)
+
+    s3 = boto3.client("s3")
+    report = validate_station(s3, args.bucket, args.station.upper(), args.date)
+    report.print_report()
+    sys.exit(report.exit_code())
+
+
+if __name__ == "__main__":
+    main()

--- a/noakweather-platform/pom.xml
+++ b/noakweather-platform/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>weather</groupId>
     <artifactId>noakweather-platform</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>1.19.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>NoakWeather Engineering Pipeline</name>

--- a/noakweather-platform/weather-analytics/pom.xml
+++ b/noakweather-platform/weather-analytics/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>1.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-analytics</artifactId>

--- a/noakweather-platform/weather-common/pom.xml
+++ b/noakweather-platform/weather-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>1.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-common</artifactId>

--- a/noakweather-platform/weather-infrastructure/pom.xml
+++ b/noakweather-platform/weather-infrastructure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>1.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-infrastructure</artifactId>

--- a/noakweather-platform/weather-ingestion/pom.xml
+++ b/noakweather-platform/weather-ingestion/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>1.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-ingestion</artifactId>

--- a/noakweather-platform/weather-processing/pom.xml
+++ b/noakweather-platform/weather-processing/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>1.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-processing</artifactId>

--- a/noakweather-platform/weather-storage/pom.xml
+++ b/noakweather-platform/weather-storage/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.18.0-SNAPSHOT</version>
+        <version>1.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-storage</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>weather</groupId>
     <artifactId>noakweather-engineering-pipeline</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>1.19.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>NoakWeather Engineering Pipeline Root</name>

--- a/wethuat_metar_ingest.sh
+++ b/wethuat_metar_ingest.sh
@@ -1,0 +1,216 @@
+#!/bin/bash
+# ============================================================================
+# UAT METAR Ingestion Sweep
+#
+# Purpose: Ingest METAR data for a broad, geographically and format-diverse
+#          set of worldwide stations, then validate the resulting Bronze
+#          layer output (raw-data + speed-layer) for each station via
+#          glue-jobs/tools/analyze_bronze_station.py, to surface any
+#          Bronze-layer parsing or ingestion issues before proceeding to
+#          Gold layer development.
+#
+# Run from the repository root, on main (no application code changes are
+# made here - this only ingests and validates live data). Requires a
+# packaged weather-ingestion jar; run ./wethp.sh first if target/*.jar
+# does not exist. Requires python3 with the dependencies in
+# glue-jobs/requirements.txt installed (boto3), and AWS credentials
+# already configured (same chain used by the AWS CLI). The existing
+# glue_env conda environment already satisfies this.
+#
+# Result semantics per station:
+#   Ingestion: OK / FAILED - did MetarIngestionApp report success?
+#   Validation: PASS / WARN / FAIL - did analyze_bronze_station.py find
+#     issues in the resulting S3 content? WARN = noteworthy but not a bug
+#     (e.g. unparsed main body tokens - this is exactly the UAT signal
+#     we're looking for). FAIL = a real structural/content problem.
+#
+# A validation failure for one station does not stop the sweep; every
+# station is attempted and every result is recorded in the summary.
+#
+# Usage: ./uat_metar_ingest.sh
+# ============================================================================
+
+set -uo pipefail
+
+INGESTION_DIR="noakweather-platform/weather-ingestion"
+JAR_PATH=$(ls "${INGESTION_DIR}"/target/weather-ingestion-*-SNAPSHOT.jar 2>/dev/null | grep -v "/original-" | head -n 1)
+
+if [ -z "$JAR_PATH" ]; then
+  echo "ERROR: No weather-ingestion jar found in ${INGESTION_DIR}/target/"
+  echo "Run ./wethp.sh first to build it."
+  exit 1
+fi
+
+VALIDATOR_SCRIPT="glue-jobs/tools/analyze_bronze_station.py"
+if [ ! -f "$VALIDATOR_SCRIPT" ]; then
+  echo "ERROR: $VALIDATOR_SCRIPT not found."
+  echo "Run this script from the repository root."
+  exit 1
+fi
+
+echo "Using jar: $JAR_PATH"
+
+echo "Checking python3/boto3 availability..."
+PYTHON3_PATH=$(command -v python3)
+if [ -z "$PYTHON3_PATH" ]; then
+  echo "ERROR: python3 not found on PATH."
+  exit 1
+fi
+echo "  python3: $PYTHON3_PATH"
+
+if ! python3 -c "import boto3" 2>/dev/null; then
+  echo "ERROR: python3 at $PYTHON3_PATH cannot import boto3."
+  echo "If you have a conda environment with boto3 installed (e.g. glue_env),"
+  echo "make sure it is active in THIS shell session before running this script:"
+  echo "  conda activate glue_env"
+  echo "  which python3   # confirm it points into the glue_env path"
+  echo "  ./wethuat_metar_ingest.sh"
+  exit 1
+fi
+echo "  boto3: OK"
+
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+LOG_DIR="logs/uat"
+if [ ! -d "$LOG_DIR" ]; then
+  echo "Creating log directory: $LOG_DIR"
+  mkdir -p "$LOG_DIR"
+else
+  echo "Log directory already exists: $LOG_DIR"
+fi
+LOG_FILE="${LOG_DIR}/uat_ingest_${TIMESTAMP}.log"
+
+# Ingestion date for validation lookups: must match the UTC date the Java
+# app used when partitioning S3 keys (ingestion time, not observation time).
+TODAY=$(date -u +%Y-%m-%d)
+
+# ----------------------------------------------------------------------------
+# Station list: ~90 stations chosen for diversity across:
+# - Units (statute miles/inHg vs meters/hPa)
+# - Hemisphere and climate (tropical, polar, desert, monsoon)
+# - Reporting conventions (CAVOK-heavy vs rarely used, RVR-heavy airports)
+# - Elevation extremes (sea level to high altitude)
+# - Automated vs staffed stations
+# ----------------------------------------------------------------------------
+STATIONS=(
+  # --- North America (SM / inHg) ---
+  KATL KJFK KORD KDFW KDEN KSFO KSEA KMIA KBOS KLAX KPHX KMCO KIAH KAFW
+  CYYZ CYVR CYUL
+  MMMX
+
+  # --- Caribbean / Central America ---
+  MKJP TJSJ TNCM
+
+  # --- UK / Ireland (fog / RVR heavy) ---
+  EGLL EGKK EGCC EIDW
+
+  # --- Western / Central Europe (meters / hPa, CAVOK common) ---
+  LFPG EDDF EDDM EHAM LEMD LIRF ESSA ENGM EKCH LSZH LOWW EPWA
+
+  # --- Eastern Europe / Russia ---
+  UUEE
+
+  # --- Middle East (heat, sandstorms) ---
+  OMDB OTHH OERK LLBG
+
+  # --- Africa ---
+  FAOR HECA DNMM GMMN HKJK
+
+  # --- Asia ---
+  RJTT RJAA RKSI ZBAA ZSPD VHHH WSSS VTBS VIDP VABB RPLL WMKK RCTP
+
+  # --- Oceania ---
+  YSSY YMML NZAA NZWN YBBN YPPH
+
+  # --- South America ---
+  SBGR SBGL SAEZ SCEL SPJC SKBO
+
+  # --- Polar / extreme cold ---
+  PAFA PANC BIRK ENSB SCCI
+
+  # --- High altitude ---
+  SLLP
+
+  # --- Pacific islands ---
+  PHNL
+)
+
+TOTAL=${#STATIONS[@]}
+INGEST_OK=0
+INGEST_FAIL=0
+INGEST_FAILED_STATIONS=()
+
+VALIDATE_PASS=0
+VALIDATE_WARN=0
+VALIDATE_FAIL=0
+VALIDATE_WARN_STATIONS=()
+VALIDATE_FAIL_STATIONS=()
+
+echo "+++++++++++++++++++++++++++++++++++++++++++++"
+echo "UAT METAR Ingestion + Validation Sweep - $TOTAL stations"
+echo "Ingestion date (UTC): $TODAY"
+echo "Log file: $LOG_FILE"
+echo "+++++++++++++++++++++++++++++++++++++++++++++"
+
+for STATION in "${STATIONS[@]}"; do
+  echo "--- $STATION ---" | tee -a "$LOG_FILE"
+
+  INGEST_OUTPUT=$(java -cp "$JAR_PATH" weather.ingestion.service.source.noaa.MetarIngestionApp "$STATION" 2>&1)
+  INGEST_EXIT=$?
+  echo "$INGEST_OUTPUT" >> "$LOG_FILE"
+
+  if [ $INGEST_EXIT -eq 0 ] && echo "$INGEST_OUTPUT" | grep -q "Successfully ingested"; then
+    echo "  Ingestion: OK"
+    INGEST_OK=$((INGEST_OK + 1))
+  else
+    echo "  Ingestion: FAILED (exit code $INGEST_EXIT)"
+    INGEST_FAIL=$((INGEST_FAIL + 1))
+    INGEST_FAILED_STATIONS+=("$STATION")
+    sleep 0.5
+    continue
+  fi
+
+  VALIDATE_OUTPUT=$(python3 "$VALIDATOR_SCRIPT" "$STATION" "$TODAY" 2>&1)
+  VALIDATE_EXIT=$?
+  echo "$VALIDATE_OUTPUT" >> "$LOG_FILE"
+
+  case $VALIDATE_EXIT in
+    0)
+      echo "  Validation: PASS"
+      VALIDATE_PASS=$((VALIDATE_PASS + 1))
+      ;;
+    2)
+      echo "  Validation: WARN (see log for details)"
+      VALIDATE_WARN=$((VALIDATE_WARN + 1))
+      VALIDATE_WARN_STATIONS+=("$STATION")
+      ;;
+    *)
+      echo "  Validation: FAILED (see log for details)"
+      VALIDATE_FAIL=$((VALIDATE_FAIL + 1))
+      VALIDATE_FAIL_STATIONS+=("$STATION")
+      ;;
+  esac
+
+  sleep 0.5
+done
+
+{
+  echo ""
+  echo "+++++++++++++++++++++++++++++++++++++++++++++"
+  echo "Ingestion:  $INGEST_OK/$TOTAL succeeded, $INGEST_FAIL failed"
+  if [ $INGEST_FAIL -gt 0 ]; then
+    echo "  Failed stations: ${INGEST_FAILED_STATIONS[*]}"
+  fi
+  echo ""
+  echo "Validation (of the $INGEST_OK successfully ingested stations):"
+  echo "  PASS: $VALIDATE_PASS"
+  echo "  WARN: $VALIDATE_WARN"
+  if [ $VALIDATE_WARN -gt 0 ]; then
+    echo "    Stations: ${VALIDATE_WARN_STATIONS[*]}"
+  fi
+  echo "  FAIL: $VALIDATE_FAIL"
+  if [ $VALIDATE_FAIL -gt 0 ]; then
+    echo "    Stations: ${VALIDATE_FAIL_STATIONS[*]}"
+  fi
+  echo "+++++++++++++++++++++++++++++++++++++++++++++"
+  echo "Full log: $LOG_FILE"
+} | tee -a "$LOG_FILE"


### PR DESCRIPTION
Adds tooling for running comprehensive real-world UAT testing across the Bronze layer ingestion pipeline, ahead of Gold layer development:

- wethuat_metar_ingest.sh: ingests METAR data for a curated, diverse set of worldwide stations (unit systems, hemispheres, climates, reporting conventions), then validates each station's resulting Bronze output. Tracks ingestion and validation results separately and continues through the full station list regardless of individual failures. Includes an initial python3/boto3 availability check to fail fast with a clear diagnostic rather than discovering a missing dependency after every station.

- glue-jobs/tools/analyze_bronze_station.py: standalone local CLI tool (not deployed to AWS Glue) validating a single station/date's Bronze layer S3 output. Checks file presence, valid JSON, duplicate JSON keys, required fields, dataType/stationId match, and raw-data/JSON content consistency. Flags unparsed content (unparsedMainBody, remarks.freeText) as a WARNING rather than a failure, since unrecognized real-world content is exactly the UAT signal this tooling exists to surface. Reuses glue-jobs/requirements.txt (boto3) rather than introducing a separate dependency surface.

First full sweep (79 stations): 66 PASS, 13 WARN, 0 FAIL. Findings triaged into 11 GitHub issues (#53-#63), tracked via a new 'METAR UAT Remediation' Kanban project board and 'UAT Round 1' milestone - covering a structural remarks-parsing corruption bug affecting both US and Canadian stations, missing-data placeholders misclassified as present weather, unsupported METAR trend forecast groups, eight country-specific unsupported remark formats, and observation year currently derived from system clock rather than NOAA's source header line.

Also fixes glue-jobs/README.md, which still documented the pre-fix double-partitioned Silver output path and a placeholder IAM role name in its example Glue job creation command; documents the new tools/ subdirectory.

Bumped noakweather-platform and all submodules from 1.18.0-SNAPSHOT to 1.19.0-SNAPSHOT (minor version bump - new capability, not a patch fix; noakweather-legacy remains at 0.0.5, untouched). Updated CHANGELOG.md accordingly.