### PR TITLE
Fix cloud type parsing corruption and add density altitude support (#53, #57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Version 1.19.1-SNAPSHOT - September 3, 2026
+
+#### UAT Round 1 Remediation - Cloud Type Parsing and Density Altitude (#53, #57)
+
+**Fixed:**
+- **Downstream parse corruption after unrecognized cloud type codes** (weather-common, weather-processing) (#53)
+  - `CloudType`'s `VALID_CLOUD_TYPES` was missing `ACC` (Altocumulus
+    Castellanus) and `ACSL` (Altocumulus Standing Lenticular Cloud), even
+    though `CLOUD_OKTA_PATTERN` already matched them at the regex level
+  - The mismatch caused `CloudType`'s constructor to throw
+    `IllegalArgumentException` during cloud type extraction, which
+    `processCloudTypeMatch()` caught and logged rather than surfaced —
+    silently dropping the cloud type from the result while still advancing
+    past it in the text, corrupting parsing of everything remaining in the
+    remarks string (including well-tested existing features like Sea Level
+    Pressure)
+  - Added `ACC` and `ACSL` to `VALID_CLOUD_TYPES` and
+    `getCloudTypeDescription()` in `CloudType.java`
+  - Broadened `CLOUD_OKTA_PATTERN`'s okta lookahead
+    (`(?=\s|$)` → `(?=\s|$|[A-Z])`) to correctly capture oktas digits in
+    chained, no-space-separated cloud type sequences (e.g. `AC1AC1CI1`)
+  - Reordered the cloud type alternation so `ACC`/`ACSL` are checked before
+    the shorter `AC` prefix.
+
+**Added:**
+- **`DENSITY ALT ####FT` remark parsing** (weather-common, weather-processing) (#57)
+  - `DENSITY_ALTITUDE_PATTERN` existed in `RegExprConst.java` but was
+    entirely unused and contained a latent bug: a trailing mandatory `\s+`
+    that would never match when the remark was the last token in the remarks
+    string (the common case in real-world Canadian METARs)
+  - Fixed the pattern to use a non-consuming lookahead
+    (`(?=\s|$)`) instead of mandatory trailing whitespace
+  - Added `densityAltitudeFeet` field to `NoaaMetarRemarks` (record,
+    builder, `isEmpty()`, `toString()`)
+  - Added `handleDensityAltitudeSequential()` handler in `NoaaMetarParser`,
+    wired into the `handleRemarks()` multi-pass chain
+
+**Testing:**
+- Added parameterized real-world regression tests (CYYZ, CYVR, CYUL) for
+  both chained cloud type parsing and density altitude extraction,
+  reflecting the exact station data found during the UAT sweep
+- Full reactor build (`wethb.sh` + `wetht.sh`) passing across all modules
+
+**Notes:**
+- Issues #53 and #57 are marked **Pending UAT** rather than Done — these
+  fixes are verified via unit tests and code review, but not yet confirmed
+  against the full worldwide UAT station corpus. Both issues will be closed
+  after a UAT re-run confirms the fixes hold across all previously affected
+  and unaffected stations.
+
 ### Version 1.19.0-SNAPSHOT - September 2, 2026
 
 #### Worldwide METAR UAT Sweep and Tooling

--- a/noakweather-platform/pom.xml
+++ b/noakweather-platform/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>weather</groupId>
     <artifactId>noakweather-platform</artifactId>
-    <version>1.19.0-SNAPSHOT</version>
+    <version>1.19.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>NoakWeather Engineering Pipeline</name>

--- a/noakweather-platform/weather-analytics/pom.xml
+++ b/noakweather-platform/weather-analytics/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.19.0-SNAPSHOT</version>
+        <version>1.19.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-analytics</artifactId>

--- a/noakweather-platform/weather-common/pom.xml
+++ b/noakweather-platform/weather-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.19.0-SNAPSHOT</version>
+        <version>1.19.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-common</artifactId>

--- a/noakweather-platform/weather-common/src/main/java/weather/model/components/remark/CloudType.java
+++ b/noakweather-platform/weather-common/src/main/java/weather/model/components/remark/CloudType.java
@@ -18,53 +18,54 @@ package weather.model.components.remark;
 
 /**
  * Immutable value object representing a cloud type observation in METAR remarks.
- *
+ * <p>
  * Cloud types describe cloud formations using standard abbreviations with optional
  * okta coverage (eighths of sky covered), intensity, and location/movement.
- *
+ * <p>
  * Format: [Intensity] CloudType [Oktas] [Location/Movement]
- *
+ * <p>
  * Examples:
- *   "SC1" → CloudType("SC", 1, null, null, null)
- *   "SC TR" → CloudType("SC", null, null, "TR", null)
- *   "MDT CU OHD" → CloudType("CU", null, "MDT", "OHD", null)
- *   "AC8" → CloudType("AC", 8, null, null, null)
- *   "CI MOVG NE" → CloudType("CI", null, null, null, "NE")
- *
+ * "SC1" → CloudType("SC", 1, null, null, null)
+ * "SC TR" → CloudType("SC", null, null, "TR", null)
+ * "MDT CU OHD" → CloudType("CU", null, "MDT", "OHD", null)
+ * "AC8" → CloudType("AC", 8, null, null, null)
+ * "CI MOVG NE" → CloudType("CI", null, null, null, "NE")
+ * <p>
  * Cloud Type Codes:
- *   CU - Cumulus
- *   TCU - Towering Cumulus
- *   CF - Cumuliform
- *   ST - Stratus
- *   SC - Stratocumulus
- *   SF - Stratiform
- *   NS - Nimbostratus
- *   AS - Altostratus
- *   AC - Altocumulus
- *   CS - Cirrostratus
- *   CC - Cirrocumulus
- *   CI - Cirrus
- *
+ * CU - Cumulus
+ * TCU - Towering Cumulus
+ * CF - Cumuliform
+ * ST - Stratus
+ * SC - Stratocumulus
+ * SF - Stratiform
+ * NS - Nimbostratus
+ * AS - Altostratus
+ * AC - Altocumulus
+ * CS - Cirrostratus
+ * CC - Cirrocumulus
+ * CI - Cirrus
+ * ACC - Altocumulus Castellanus
+ * ACSL - Altocumulus Standing Lenticular Cloud
+ * <p>
  * Oktas: 1-8 (eighths of sky covered), null if not specified
- *
+ * <p>
  * Intensity:
- *   MDT - Moderate
- *
+ * MDT - Moderate
+ * <p>
  * Location:
- *   OHD - Overhead
- *   OHD-ALQDS - Overhead all quadrants
- *   ALQDS - All quadrants
- *   TR - Trace
- *
+ * OHD - Overhead
+ * OHD-ALQDS - Overhead all quadrants
+ * ALQDS - All quadrants
+ * TR - Trace
+ * <p>
  * Movement Direction:
- *   N, S, E, W, NE, NW, SE, SW
+ * N, S, E, W, NE, NW, SE, SW
  *
- * @param cloudType Cloud type code (CU, CI, AC, etc.) - required
- * @param oktas Coverage in eighths (1-8), null if not specified
- * @param intensity Intensity modifier (MDT), null if not specified
- * @param location Location indicator (OHD, TR, etc.), null if not specified
+ * @param cloudType         Cloud type code (CU, CI, AC, etc.) - required
+ * @param oktas             Coverage in eighths (1-8), null if not specified
+ * @param intensity         Intensity modifier (MDT), null if not specified
+ * @param location          Location indicator (OHD, TR, etc.), null if not specified
  * @param movementDirection Movement direction (N, NE, etc.), null if not specified
- *
  * @author bclasky1539
  *
  */
@@ -80,7 +81,7 @@ public record CloudType(
 
     // Valid cloud type codes
     private static final String[] VALID_CLOUD_TYPES = {
-            "CU", "TCU", "CF", "ST", "SC", "SF", "NS", "AS", "AC", "CS", "CC", "CI"
+            "CU", "TCU", "CF", "ST", "SC", "SF", "NS", "AS", "AC", "CS", "CC", "CI", "ACC", "ACSL"
     };
 
     // Valid intensity modifiers
@@ -299,6 +300,8 @@ public record CloudType(
             case "CS" -> "Cirrostratus";
             case "CC" -> "Cirrocumulus";
             case "CI" -> "Cirrus";
+            case "ACC" -> "Altocumulus Castellanus";
+            case "ACSL" -> "Altocumulus Standing Lenticular Cloud";
             default -> cloudType;
         };
     }
@@ -317,13 +320,13 @@ public record CloudType(
 
     /**
      * Get a human-readable summary of the cloud type.
-     *
+     * <p>
      * Examples:
-     *   "Stratocumulus (1/8)"
-     *   "Stratocumulus (trace)"
-     *   "Cumulus (moderate, overhead)"
-     *   "Altocumulus (8/8)"
-     *   "Cirrus (moving NE)"
+     * "Stratocumulus (1/8)"
+     * "Stratocumulus (trace)"
+     * "Cumulus (moderate, overhead)"
+     * "Altocumulus (8/8)"
+     * "Cirrus (moving NE)"
      *
      * @return formatted string describing the cloud type
      */
@@ -386,7 +389,7 @@ public record CloudType(
      * Factory method for cloud type with oktas.
      *
      * @param cloudType cloud type code
-     * @param oktas coverage in eighths
+     * @param oktas     coverage in eighths
      * @return new CloudType
      */
     public static CloudType of(String cloudType, int oktas) {
@@ -397,7 +400,7 @@ public record CloudType(
      * Factory method for cloud type with location.
      *
      * @param cloudType cloud type code
-     * @param location location indicator
+     * @param location  location indicator
      * @return new CloudType
      */
     public static CloudType withLocation(String cloudType, String location) {

--- a/noakweather-platform/weather-common/src/main/java/weather/model/components/remark/NoaaMetarRemarks.java
+++ b/noakweather-platform/weather-common/src/main/java/weather/model/components/remark/NoaaMetarRemarks.java
@@ -28,43 +28,44 @@ import java.util.stream.Collectors;
 
 /**
  * Contains remarks (supplemental information) from a METAR or SPECI report.
- *
+ * <p>
  * Remarks appear after the "RMK" delimiter in METAR/SPECI reports and provide
  * additional meteorological information beyond the main observation body. All fields
  * are optional as remarks content varies by station and conditions.
- *
+ * <p>
  * This is an immutable record that uses the Builder pattern for construction
  * since all fields are optional.
- *
+ * <p>
  * Fields are nullable as not all remarks are present in every METAR.
- *
- *  * @param automatedStationType AO1 or AO2 indicator
- *  * @param seaLevelPressure Sea level pressure in hPa (SLP)
- *  * @param hourlyTemperature Hourly temperature and dewpoint (T-group)
- *  * @param peakWind Peak wind information
- *  * @param windShift Wind shift information
- *  * @param variableVisibility Variable visibility data
- *  * @param CeilingSecondSite Ceiling height at second observation site
- *  * @param obscurationLayers Obscuration Layer information
- *  * @param cloudTypes Cloud Type information
- *  * @param towerVisibility Tower visibility (if different from surface)
- *  * @param surfaceVisibility Surface visibility (if different from prevailing)
- *  * @param hourlyPrecipitation Hourly precipitation amount (P)
- *  * @param precipitation3Hour 3-hour precipitation amount
- *  * @param precipitation6Hour 6-hour precipitation amount
- *  * @param precipitation24Hour 24-hour precipitation amount
- *  * @param snowDepth Snow depth on ground
- *  * @param hailSize Hail size in inches
- *  * @param weatherEvents List of weather events (beginning/ending times)
- *  * @param thunderstormLocations List of thunderstorm/cloud locations
- *  * @param pressureTendency 3-hour pressure tendency
- *  * @param sixHourMaxTemperature 6-hour maximum temperature
- *  * @param sixHourMinTemperature 6-hour minimum temperature
- *  * @param twentyFourHourMaxTemperature 24-hour maximum temperature
- *  * @param twentyFourHourMinTemperature 24-hour minimum temperature
- *  * @param automatedMaintenanceIndicators List of Automated Maintenance Indicators
- *  * @param maintenanceRequired Boolean if maintanence is required
- *  * @param freeText Unparsed remarks text
+ * <p>
+ * * @param automatedStationType AO1 or AO2 indicator
+ * * @param seaLevelPressure Sea level pressure in hPa (SLP)
+ * * @param hourlyTemperature Hourly temperature and dewpoint (T-group)
+ * * @param peakWind Peak wind information
+ * * @param windShift Wind shift information
+ * * @param variableVisibility Variable visibility data
+ * * @param CeilingSecondSite Ceiling height at second observation site
+ * * @param obscurationLayers Obscuration Layer information
+ * * @param cloudTypes Cloud Type information
+ * * @param towerVisibility Tower visibility (if different from surface)
+ * * @param surfaceVisibility Surface visibility (if different from prevailing)
+ * * @param hourlyPrecipitation Hourly precipitation amount (P)
+ * * @param precipitation3Hour 3-hour precipitation amount
+ * * @param precipitation6Hour 6-hour precipitation amount
+ * * @param precipitation24Hour 24-hour precipitation amount
+ * * @param snowDepth Snow depth on ground
+ * * @param hailSize Hail size in inches
+ * * @param weatherEvents List of weather events (beginning/ending times)
+ * * @param thunderstormLocations List of thunderstorm/cloud locations
+ * * @param pressureTendency 3-hour pressure tendency
+ * * @param sixHourMaxTemperature 6-hour maximum temperature
+ * * @param sixHourMinTemperature 6-hour minimum temperature
+ * * @param twentyFourHourMaxTemperature 24-hour maximum temperature
+ * * @param twentyFourHourMinTemperature 24-hour minimum temperature
+ * * @param densityAltitudeFeet Density Altitude
+ * * @param automatedMaintenanceIndicators List of Automated Maintenance Indicators
+ * * @param maintenanceRequired Boolean if maintenance is required
+ * * @param freeText Unparsed remarks text
  *
  * @author bclasky1539
  *
@@ -94,6 +95,7 @@ public record NoaaMetarRemarks(
         Temperature sixHourMinTemperature,
         Temperature twentyFourHourMaxTemperature,
         Temperature twentyFourHourMinTemperature,
+        Integer densityAltitudeFeet,
         List<AutomatedMaintenanceIndicator> automatedMaintenanceIndicators,
         Boolean maintenanceRequired,
         String freeText
@@ -121,11 +123,11 @@ public record NoaaMetarRemarks(
      */
     public static NoaaMetarRemarks empty() {
         return new NoaaMetarRemarks(null, null, null, null,
-                null, null, null,null, null, List.of(),
-                List.of(), null,null, null,null,
-                null, null, List.of(), List.of(),null,
-                null, null,null,
-                null, List.of(),null, null);
+                null, null, null, null, null, List.of(),
+                List.of(), null, null, null, null,
+                null, null, List.of(), List.of(), null,
+                null, null, null,
+                null, null, List.of(), null, null);
     }
 
     /**
@@ -158,6 +160,7 @@ public record NoaaMetarRemarks(
                 && sixHourMinTemperature == null
                 && twentyFourHourMaxTemperature == null
                 && twentyFourHourMinTemperature == null
+                && densityAltitudeFeet == null
                 && (automatedMaintenanceIndicators == null || automatedMaintenanceIndicators.isEmpty())
                 && maintenanceRequired == null
                 && (freeText == null || freeText.isBlank());
@@ -211,6 +214,7 @@ public record NoaaMetarRemarks(
         private Temperature sixHourMinTemperature;
         private Temperature twentyFourHourMaxTemperature;
         private Temperature twentyFourHourMinTemperature;
+        private Integer densityAltitudeFeet;
         private List<AutomatedMaintenanceIndicator> automatedMaintenanceIndicators = new ArrayList<>();
         private Boolean maintenanceRequired;
         private String freeText;
@@ -448,6 +452,17 @@ public record NoaaMetarRemarks(
         }
 
         /**
+         * Sets the Density Altitude.
+         *
+         * @param densityAltitudeFeet the density altitude
+         * @return this builder
+         */
+        public Builder densityAltitudeFeet(Integer densityAltitudeFeet) {
+            this.densityAltitudeFeet = densityAltitudeFeet;
+            return this;
+        }
+
+        /**
          * Sets the hail size.
          *
          * @param hailSize the hail size from GR group
@@ -650,6 +665,7 @@ public record NoaaMetarRemarks(
                     sixHourMinTemperature,
                     twentyFourHourMaxTemperature,
                     twentyFourHourMinTemperature,
+                    densityAltitudeFeet,
                     List.copyOf(automatedMaintenanceIndicators),
                     maintenanceRequired,
                     freeText
@@ -711,6 +727,7 @@ public record NoaaMetarRemarks(
                 t -> String.format(TEMPERATURE_FORMAT, t.celsius()));
         addIfPresent(parts, twentyFourHourMinTemperature, "twentyFourHourMinTemp",
                 t -> String.format(TEMPERATURE_FORMAT, t.celsius()));
+        addIfPresent(parts, densityAltitudeFeet, "densityAltitudeFeet", Object::toString);
         if (automatedMaintenanceIndicators != null && !automatedMaintenanceIndicators.isEmpty()) {
             parts.add("automatedMaintenance=" + automatedMaintenanceIndicators.stream()
                     .map(AutomatedMaintenanceIndicator::toString)

--- a/noakweather-platform/weather-common/src/test/java/weather/model/components/remark/NoaaMetarRemarksTest.java
+++ b/noakweather-platform/weather-common/src/test/java/weather/model/components/remark/NoaaMetarRemarksTest.java
@@ -3314,6 +3314,40 @@ class NoaaMetarRemarksTest {
         assertFalse(remarks.isEmpty());
     }
 
+    // ========== DENSITY ALTITUDE TESTS ==========
+
+    @Test
+    @DisplayName("Should build remarks with densityAltitudeFeet via builder")
+    void testBuilder_DensityAltitudeFeet() {
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .densityAltitudeFeet(1500)
+                .build();
+
+        assertThat(remarks.densityAltitudeFeet()).isEqualTo(1500);
+        assertThat(remarks.isEmpty()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should handle null densityAltitudeFeet via builder")
+    void testBuilder_NullDensityAltitudeFeet() {
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .densityAltitudeFeet(null)
+                .build();
+
+        assertThat(remarks.densityAltitudeFeet()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should include densityAltitudeFeet in toString()")
+    void testToString_DensityAltitudeFeet() {
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .densityAltitudeFeet(1500)
+                .build();
+
+        String str = remarks.toString();
+        assertThat(str).contains("densityAltitudeFeet=1500");
+    }
+
     // ========== CORRECTED TESTS FOR NoaaMetarRemarksTest.java ==========
 
     @Test

--- a/noakweather-platform/weather-common/src/test/java/weather/model/components/remark/NoaaMetarRemarksTest.java
+++ b/noakweather-platform/weather-common/src/test/java/weather/model/components/remark/NoaaMetarRemarksTest.java
@@ -168,11 +168,11 @@ class NoaaMetarRemarksTest {
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 stationType, slp, temp, dewpoint, null, null, null, null,
-                null, null, null,null,null,
-                null, null,null,null, null,
-                null, null,null, null,
-                null,null, null,
-                null,freeText
+                null, null, null, null, null,
+                null, null, null, null, null,
+                null, null, null, null,
+                null, null, null,
+                null, null, freeText
         );
 
         assertEquals(stationType, remarks.automatedStationType());
@@ -344,10 +344,10 @@ class NoaaMetarRemarksTest {
                 null, null, null, null, peakWind,
                 null, null, null, null, null,
                 null, null, null,
-                null,null, null, null, null,
+                null, null, null, null, null,
                 null, null, null, null,
                 null, null, null,
-                null, null
+                null, null, null
         );
 
         assertEquals(peakWind, remarks.peakWind());
@@ -361,11 +361,11 @@ class NoaaMetarRemarksTest {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
                 windShift, null, null, null, null,
-                null,null, null,
-                null,null, null, null, null,
+                null, null, null,
+                null, null, null, null, null,
                 null, null, null, null,
                 null, null, null,
-                null, null
+                null, null, null
         );
 
         assertNull(remarks.peakWind());
@@ -438,10 +438,10 @@ class NoaaMetarRemarksTest {
                 null, null, null, null, null,
                 null, varVis, null, null, null,
                 null, null, null,
-                null,null, null, null, null,
+                null, null, null, null, null,
                 null, null, null, null,
                 null, null, null,
-                null, null
+                null, null, null
         );
 
         assertEquals(varVis, remarks.variableVisibility());
@@ -644,10 +644,10 @@ class NoaaMetarRemarksTest {
                 null, null, null, null, null,
                 null, null, null, null, null,
                 null, towerVis, null,
-                null,null, null, null, null,
-                null, null,null, null,
-                null, null,null,
-                null, null
+                null, null, null, null, null,
+                null, null, null, null,
+                null, null, null,
+                null, null, null
         );
 
         assertEquals(towerVis, remarks.towerVisibility());
@@ -661,12 +661,12 @@ class NoaaMetarRemarksTest {
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
-                null, null, null,null, null,
+                null, null, null, null, null,
                 null, null, surfaceVis,
-                null,null, null, null, null,
+                null, null, null, null, null,
                 null, null, null, null,
-                null, null,null,
-                null, null
+                null, null, null,
+                null, null, null
         );
 
         assertNull(remarks.towerVisibility());
@@ -683,10 +683,10 @@ class NoaaMetarRemarksTest {
                 null, null, null, null, null,
                 null, null, null, null, null,
                 null, towerVis, surfaceVis,
-                null,null, null, null,null,
+                null, null, null, null, null,
                 null, null, null, null,
-                null, null,null,
-                null, null
+                null, null, null,
+                null, null, null
         );
 
         assertEquals(towerVis, remarks.towerVisibility());
@@ -891,10 +891,11 @@ class NoaaMetarRemarksTest {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
                 null, null, null, null, null,
-                null,null, null,
-                 hourly, null,null, null, null, null,
+                null, null, null,
+                hourly, null, null, null, null, null,
                 null, null, null, null,
-                null, null, null, null
+                null, null, null, null,
+                null
         );
 
         assertEquals(hourly, remarks.hourlyPrecipitation());
@@ -910,10 +911,11 @@ class NoaaMetarRemarksTest {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
                 null, null, null, null, null,
-                null,null, null,
-                null, sixHour,null, null, null, null,
+                null, null, null,
+                null, sixHour, null, null, null, null,
                 null, null, null, null,
-                null, null, null, null
+                null, null, null, null,
+                null
         );
 
         assertNull(remarks.hourlyPrecipitation());
@@ -929,10 +931,11 @@ class NoaaMetarRemarksTest {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
                 null, null, null, null, null,
-                null,null, null,
-                null,null, twentyFourHour, null, null, null,
+                null, null, null,
+                null, null, twentyFourHour, null, null, null,
                 null, null, null, null,
-                null, null, null, null
+                null, null, null, null,
+                null
         );
 
         assertNull(remarks.hourlyPrecipitation());
@@ -950,10 +953,11 @@ class NoaaMetarRemarksTest {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
                 null, null, null, null, null,
-                null,null, null,
+                null, null, null,
                 hourly, sixHour, twentyFourHour, null, null, null,
                 null, null, null, null,
-                null, null, null, null
+                null, null, null, null,
+                null
         );
 
         assertEquals(hourly, remarks.hourlyPrecipitation());
@@ -1197,11 +1201,11 @@ class NoaaMetarRemarksTest {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
                 null, null, null, null, null,
-                null,null, null,
-                null,null, null, hailSize, null,
+                null, null, null,
+                null, null, null, hailSize, null,
                 null, null, null, null,
                 null, null, null,
-                null, null
+                null, null, null
         );
 
         assertEquals(hailSize, remarks.hailSize());
@@ -1213,11 +1217,11 @@ class NoaaMetarRemarksTest {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
                 null, null, null, null, null,
-                null,null, null,
-                null,null, null, null, null,
-                null,null, null, null,
                 null, null, null,
-                null, null
+                null, null, null, null, null,
+                null, null, null, null,
+                null, null, null,
+                null, null, null
         );
 
         assertNull(remarks.hailSize());
@@ -1416,11 +1420,11 @@ class NoaaMetarRemarksTest {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
                 null, null, null, null, null,
-                null,null, null,
-                null,null, null, null, null,
-                 List.of(location), null, null, null,
                 null, null, null,
-                null, null
+                null, null, null, null, null,
+                List.of(location), null, null, null,
+                null, null, null,
+                null, null, null
         );
 
         assertEquals(1, remarks.thunderstormLocations().size());
@@ -1436,11 +1440,11 @@ class NoaaMetarRemarksTest {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
                 null, null, null, null, null,
-                null,null, null,
-                null,null, null, null, null,
-                 List.of(location1, location2), null, null, null,
                 null, null, null,
-                null, null
+                null, null, null, null, null,
+                List.of(location1, location2), null, null, null,
+                null, null, null,
+                null, null, null
         );
 
         assertEquals(2, remarks.thunderstormLocations().size());
@@ -1748,7 +1752,7 @@ class NoaaMetarRemarksTest {
         ThunderstormLocation newLocation = ThunderstormLocation.of("CB", "W");
 
         assertThrows(UnsupportedOperationException.class, () ->
-                        locations.add(newLocation)
+                locations.add(newLocation)
         );
     }
 
@@ -1815,12 +1819,12 @@ class NoaaMetarRemarksTest {
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
-                null, null, null,null, null,
-                null,null, null,
-                null,null, null, null, List.of(event),
+                null, null, null, null, null,
+                null, null, null,
+                null, null, null, null, List.of(event),
                 null, null, null, null,
                 null, null, null,
-                null, null
+                null, null, null
         );
 
         assertEquals(1, remarks.weatherEvents().size());
@@ -1836,11 +1840,11 @@ class NoaaMetarRemarksTest {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
                 null, null, null, null, null,
-                null,null, null,
-                null,null, null, null, List.of(event1, event2),
+                null, null, null,
+                null, null, null, null, List.of(event1, event2),
                 null, null, null, null,
                 null, null, null,
-                null, null
+                null, null, null
         );
 
         assertEquals(2, remarks.weatherEvents().size());
@@ -2222,11 +2226,11 @@ class NoaaMetarRemarksTest {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
                 null, null, null, null, null,
-                null,null, null,
-                null,null, null, null, null,
+                null, null, null,
+                null, null, null, null, null,
                 null, tendency, null, null,
                 null, null, null,
-                null, null
+                null, null, null
         );
 
         assertEquals(tendency, remarks.pressureTendency());
@@ -2238,11 +2242,11 @@ class NoaaMetarRemarksTest {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
                 null, null, null, null, null,
-                null,null, null,
-                null,null, null, null, null,
+                null, null, null,
+                null, null, null, null, null,
                 null, null, null, null,
                 null, null, null,
-                null, null
+                null, null, null
         );
 
         assertNull(remarks.pressureTendency());
@@ -3879,6 +3883,7 @@ class NoaaMetarRemarksTest {
         Temperature sixHourMinTemp = Temperature.of(-0.1);
         Temperature twentyFourHourMaxTemp = Temperature.of(4.6);
         Temperature twentyFourHourMinTemp = Temperature.of(-0.6);
+        Integer densityAltitudeFeet = 1500;
         List<AutomatedMaintenanceIndicator> automatedMaintenanceIndicators = List.of(
                 AutomatedMaintenanceIndicator.of("TSNO"),
                 AutomatedMaintenanceIndicator.of("VISNO", "RWY06")
@@ -3890,7 +3895,7 @@ class NoaaMetarRemarksTest {
                 stationType, slp, temp, dewpoint, peakWind, windShift, varVis, variableCeiling, ceilingSecondSite,
                 obscurationLayers, cloudTypes, towerVis, surfaceVis, hourly, sixHour, twentyFourHour, hailSize, weatherEvents,
                 thunderstormLocations, tendency, sixHourMaxTemp, sixHourMinTemp, twentyFourHourMaxTemp,
-                twentyFourHourMinTemp, automatedMaintenanceIndicators, maintenanceRequired, freeText
+                twentyFourHourMinTemp, densityAltitudeFeet, automatedMaintenanceIndicators, maintenanceRequired, freeText
         );
 
         // Verify first 13 fields
@@ -3950,6 +3955,7 @@ class NoaaMetarRemarksTest {
         Temperature sixHourMinTemp = Temperature.of(-0.1);
         Temperature twentyFourHourMaxTemp = Temperature.of(4.6);
         Temperature twentyFourHourMinTemp = Temperature.of(-0.6);
+        Integer densityAltitudeFeet = 1500;
         List<AutomatedMaintenanceIndicator> automatedMaintenanceIndicators = List.of(
                 AutomatedMaintenanceIndicator.of("TSNO"),
                 AutomatedMaintenanceIndicator.of("VISNO", "RWY06")
@@ -3961,10 +3967,10 @@ class NoaaMetarRemarksTest {
                 stationType, slp, temp, dewpoint, peakWind, windShift, varVis, variableCeiling, ceilingSecondSite,
                 obscurationLayers, cloudTypes, towerVis, surfaceVis, hourly, sixHour, twentyFourHour, hailSize, weatherEvents,
                 thunderstormLocations, tendency, sixHourMaxTemp, sixHourMinTemp, twentyFourHourMaxTemp,
-                twentyFourHourMinTemp, automatedMaintenanceIndicators, maintenanceRequired, freeText
+                twentyFourHourMinTemp, densityAltitudeFeet, automatedMaintenanceIndicators, maintenanceRequired, freeText
         );
 
-        // Verify remaining 14 fields
+        // Verify remaining 15 fields
         assertAll("Second half of fields should be correctly set",
                 () -> assertEquals(hourly, remarks.hourlyPrecipitation()),
                 () -> assertEquals(sixHour, remarks.sixHourPrecipitation()),
@@ -3977,6 +3983,7 @@ class NoaaMetarRemarksTest {
                 () -> assertEquals(sixHourMinTemp, remarks.sixHourMinTemperature()),
                 () -> assertEquals(twentyFourHourMaxTemp, remarks.twentyFourHourMaxTemperature()),
                 () -> assertEquals(twentyFourHourMinTemp, remarks.twentyFourHourMinTemperature()),
+                () -> assertEquals(densityAltitudeFeet, remarks.densityAltitudeFeet()),
                 () -> assertEquals(automatedMaintenanceIndicators, remarks.automatedMaintenanceIndicators()),
                 () -> assertEquals(maintenanceRequired, remarks.maintenanceRequired()),
                 () -> assertEquals(freeText, remarks.freeText())

--- a/noakweather-platform/weather-common/src/test/java/weather/model/components/remark/NoaaMetarRemarksTest.java
+++ b/noakweather-platform/weather-common/src/test/java/weather/model/components/remark/NoaaMetarRemarksTest.java
@@ -3199,6 +3199,31 @@ class NoaaMetarRemarksTest {
         assertThat(remarks.cloudTypes().get(3).cloudType()).isEqualTo("CI");
     }
 
+    @ParameterizedTest
+    @CsvSource({
+            "CU, Cumulus",
+            "TCU, Towering Cumulus",
+            "CF, Cumuliform",
+            "ST, Stratus",
+            "SC, Stratocumulus",
+            "SF, Stratiform",
+            "NS, Nimbostratus",
+            "AS, Altostratus",
+            "AC, Altocumulus",
+            "CS, Cirrostratus",
+            "CC, Cirrocumulus",
+            "CI, Cirrus",
+            "ACC, Altocumulus Castellanus",
+            "ACSL, Altocumulus Standing Lenticular Cloud"
+    })
+    @DisplayName("Should generate correct description for all cloud type codes")
+    void testGetCloudTypeDescription_AllCodes(String code, String expectedDescription) {
+        CloudType cloudType = CloudType.of(code, 1);
+
+        assertThat(cloudType.getCloudTypeDescription())
+                .isEqualTo(expectedDescription);
+    }
+
     @Test
     @DisplayName("Should make defensive copy of cloud types list")
     void testBuilder_DefensiveCopyOfCloudTypes() {

--- a/noakweather-platform/weather-infrastructure/pom.xml
+++ b/noakweather-platform/weather-infrastructure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.19.0-SNAPSHOT</version>
+        <version>1.19.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-infrastructure</artifactId>

--- a/noakweather-platform/weather-ingestion/pom.xml
+++ b/noakweather-platform/weather-ingestion/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.19.0-SNAPSHOT</version>
+        <version>1.19.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-ingestion</artifactId>

--- a/noakweather-platform/weather-processing/pom.xml
+++ b/noakweather-platform/weather-processing/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.19.0-SNAPSHOT</version>
+        <version>1.19.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-processing</artifactId>

--- a/noakweather-platform/weather-processing/src/main/java/weather/processing/parser/noaa/NoaaMetarParser.java
+++ b/noakweather-platform/weather-processing/src/main/java/weather/processing/parser/noaa/NoaaMetarParser.java
@@ -46,7 +46,7 @@ import static weather.processing.parser.noaa.RegExprConst.*;
  * <p>
  * METAR Format Example:
  * "2025/11/14 22:52
- *  METAR KJFK 142252Z 19005KT 10SM FEW100 FEW250 16/M03 A3012 RMK AO2 SLP214 T01611028"
+ * METAR KJFK 142252Z 19005KT 10SM FEW100 FEW250 16/M03 A3012 RMK AO2 SLP214 T01611028"
  * <p>
  * Components:
  * - METAR: Report type
@@ -244,8 +244,8 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
     /**
      * Parse token string using ordered pattern handlers from registry.
      *
-     * @param token The token string to parse
-     * @param handlers Ordered map of patterns and their handlers from NoaaAviationWeatherPatternRegistry
+     * @param token        The token string to parse
+     * @param handlers     Ordered map of patterns and their handlers from NoaaAviationWeatherPatternRegistry
      * @param handlersType Type of handlers ("MAIN" or "REMARK") for logging
      * @return Remaining unparsed token string
      */
@@ -273,7 +273,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
     /**
      * Try all patterns against the token and return updated token after first match.
      *
-     * @param token Current token to parse
+     * @param token    Current token to parse
      * @param handlers Pattern handlers to try
      * @return Updated token after match, or original token if no match
      */
@@ -301,8 +301,8 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
     /**
      * Try a single pattern against the token, applying it repeatedly if configured.
      *
-     * @param token Current token to parse
-     * @param pattern Pattern to try
+     * @param token       Current token to parse
+     * @param pattern     Pattern to try
      * @param handlerInfo Handler metadata
      * @return Updated token after all matches, or original token if no match
      */
@@ -376,7 +376,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * sky conditions) are inherited from NoaaAviationWeatherParser.
      *
      * @param handlerName The name of the handler from NoaaAviationWeatherPatternRegistry
-     * @param matcher The regex matcher with captured groups
+     * @param matcher     The regex matcher with captured groups
      */
     private void handlePattern(String handlerName, Matcher matcher) {
         try {
@@ -504,11 +504,12 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
     /**
      * Internal helper record to pass RVR range values between methods.
      *
-     * @param visualRange Single value (null if variable)
-     * @param variableLow Variable low value (null if single)
+     * @param visualRange  Single value (null if variable)
+     * @param variableLow  Variable low value (null if single)
      * @param variableHigh Variable high value (null if single)
      */
-    private record RvrRange(Integer visualRange, Integer variableLow, Integer variableHigh) {}
+    private record RvrRange(Integer visualRange, Integer variableLow, Integer variableHigh) {
+    }
 
     /**
      * Override base class to provide full RVR handling for METAR.
@@ -569,7 +570,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
     /**
      * Parse RVR values from matcher and add to weather data.
      *
-     * @param matcher The regex matcher
+     * @param matcher    The regex matcher
      * @param runwayName The runway identifier
      */
     private void parseAndAddRvr(Matcher matcher, String runwayName) {
@@ -601,7 +602,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
     /**
      * Parse RVR numeric value.
      *
-     * @param value The string value to parse
+     * @param value      The string value to parse
      * @param runwayName The runway identifier (for logging)
      * @return Parsed integer or null if parsing fails
      */
@@ -639,7 +640,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
     /**
      * Parse variable range from high value if present.
      *
-     * @param matcher The regex matcher
+     * @param matcher  The regex matcher
      * @param lowValue The low value already parsed
      * @return RvrRange object with appropriate values
      */
@@ -665,7 +666,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
     /**
      * Extract trend indicator from unit group.
      *
-     * @param unit The unit group from regex
+     * @param unit       The unit group from regex
      * @param runwayName The runway identifier (for logging)
      * @return Trend indicator (N/D/U) or null
      */
@@ -691,9 +692,9 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * Create RunwayVisualRange object and add to weather data.
      *
      * @param runwayName The runway identifier
-     * @param range The RVR range values
-     * @param prefix The M/P prefix
-     * @param trend The trend indicator
+     * @param range      The RVR range values
+     * @param prefix     The M/P prefix
+     * @param trend      The trend indicator
      */
     private void createAndAddRvr(String runwayName, RvrRange range, String prefix, String trend) {
         try {
@@ -769,7 +770,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * - Missing indicators (//, XX, MM) → null
      * - Null or blank → null
      *
-     * @param sign the sign indicator ("M", "-", or null)
+     * @param sign   the sign indicator ("M", "-", or null)
      * @param digits the temperature digits (e.g., "05", "22")
      * @return temperature in Celsius, or null if missing/unknown
      */
@@ -848,9 +849,9 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * - 4 digits starting with 0 or 1 → hectopascals
      * - 3 digits → hectopascals
      *
-     * @param unit1 Prefix unit indicator
+     * @param unit1       Prefix unit indicator
      * @param pressureStr Pressure digits
-     * @param unit2 Suffix unit indicator
+     * @param unit2       Suffix unit indicator
      * @return Pressure object, or null if invalid
      */
     private Pressure parsePressure(String unit1, String pressureStr, String unit2) {
@@ -887,7 +888,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * Parse pressure with unit prefix (A, AA, Q, QNH).
      *
      * @param prefix Unit prefix
-     * @param value Pressure value
+     * @param value  Pressure value
      * @return Pressure object
      */
     private Pressure parsePressureWithPrefix(String prefix, int value) {
@@ -971,7 +972,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * This is a stub that logs when a pattern is matched by the registry.
      * The actual parsing is done by sequential handlers in handleRemarks().
      *
-     * @param matcher The regex matcher with captured groups
+     * @param matcher    The regex matcher with captured groups
      * @param remarkType The type of remark for logging
      */
     private void handleRemarkRegistry(Matcher matcher, String remarkType) {
@@ -1017,7 +1018,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * as free text. Called after the main body has been parsed.
      *
      * @param remarksText the remarks text (everything after RMK)
-     * @param metarData the METAR data object to populate
+     * @param metarData   the METAR data object to populate
      */
     private void handleRemarks(String remarksText, NoaaMetarData metarData) {
         if (remarksText == null || remarksText.isBlank()) {
@@ -1052,6 +1053,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
             remaining = handlePressureTendencySequential(remaining, remarksBuilder);
             remaining = handle6HourMaxMinTemperatureSequential(remaining, remarksBuilder);
             remaining = handle24HourMaxMinTemperatureSequential(remaining, remarksBuilder);
+            remaining = handleDensityAltitudeSequential(remaining, remarksBuilder);
             remaining = handleAutomatedMaintenanceSequential(remaining, remarksBuilder);
 
             // Continue while we're making progress
@@ -1141,7 +1143,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * - A01/A02 = OCR error variants (O misread as 0)
      *
      * @param remarksText the remaining remarks text to process
-     * @param remarks the remarks builder to populate
+     * @param remarks     the remarks builder to populate
      * @return the remaining text after this remark is processed
      */
     private String handleAutomatedStationType(String remarksText, NoaaMetarRemarks.Builder remarks) {
@@ -1192,7 +1194,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * - If ppp < 500: Sea level pressure = 1000 + (ppp / 10) hPa
      *
      * @param remarksText the remaining remarks text to process
-     * @param remarks the remarks builder to populate
+     * @param remarks     the remarks builder to populate
      * @return the remaining text after this remark is processed
      */
     private String handleSeaLevelPressureSequential(String remarksText, NoaaMetarRemarks.Builder remarks) {
@@ -1259,7 +1261,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * - T0233 → temp=+23.3°C, dewpoint=not reported
      *
      * @param remarksText the remaining remarks text to process
-     * @param remarks the remarks builder to populate
+     * @param remarks     the remarks builder to populate
      * @return the remaining text after this remark is processed
      */
     private String handleHourlyTemperatureSequential(String remarksText, NoaaMetarRemarks.Builder remarks) {
@@ -1340,7 +1342,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * - PK WND P100/2145 → dir=unknown, speed=100kt, time=21:45 UTC
      *
      * @param remarksText the remaining remarks text to process
-     * @param remarks the remarks builder to populate
+     * @param remarks     the remarks builder to populate
      * @return the remaining text after this remark is processed
      */
     private String handlePeakWindSequential(String remarksText, NoaaMetarRemarks.Builder remarks) {
@@ -1418,7 +1420,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * - WSHFT 30 → hour=null, minute=30, no frontal passage
      *
      * @param remarksText the remaining remarks text to process
-     * @param remarks the remarks builder to populate
+     * @param remarks     the remarks builder to populate
      * @return the remaining text after this remark is processed
      */
     private String handleWindShiftSequential(String remarksText, NoaaMetarRemarks.Builder remarks) {
@@ -1483,7 +1485,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * - VIS 1 1/4V3 → min=1.25 SM, max=3 SM
      *
      * @param remarksText the remaining remarks text to process
-     * @param remarks the remarks builder to populate
+     * @param remarks     the remarks builder to populate
      * @return the remaining text after this remark is processed
      */
     private String handleVariableVisibilitySequential(String remarksText, NoaaMetarRemarks.Builder remarks) {
@@ -1630,7 +1632,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * - TWR VIS 2 → Tower visibility 2 SM
      *
      * @param remarksText the remaining remarks text to process
-     * @param remarks the remarks builder to populate
+     * @param remarks     the remarks builder to populate
      * @return the remaining text after this remark is processed
      */
     private String handleTowerSurfaceVisibilitySequential(String remarksText, NoaaMetarRemarks.Builder remarks) {
@@ -1693,10 +1695,10 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
     /**
      * Set the appropriate visibility field based on type.
      *
-     * @param type the visibility type (TWR VIS or SFC VIS)
+     * @param type       the visibility type (TWR VIS or SFC VIS)
      * @param visibility the parsed visibility
-     * @param distStr the original distance string (for logging)
-     * @param remarks the remarks builder to populate
+     * @param distStr    the original distance string (for logging)
+     * @param remarks    the remarks builder to populate
      */
     private void setVisibilityByType(String type, Visibility visibility, String distStr,
                                      NoaaMetarRemarks.Builder remarks) {
@@ -1723,7 +1725,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * - P//// → Trace
      *
      * @param remarksText the remaining remarks text to process
-     * @param remarks the remarks builder to populate
+     * @param remarks     the remarks builder to populate
      * @return the remaining text after this remark is processed
      */
     private String handleHourlyPrecipitationSequential(String remarksText, NoaaMetarRemarks.Builder remarks) {
@@ -1773,7 +1775,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * - 6//// → Trace (6-hour)
      *
      * @param remarksText the remaining remarks text to process
-     * @param remarks the remarks builder to populate
+     * @param remarks     the remarks builder to populate
      * @return the remaining text after this remark is processed
      */
     private String handleMultiHourPrecipitationSequential(String remarksText, NoaaMetarRemarks.Builder remarks) {
@@ -1817,6 +1819,42 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
     }
 
     /**
+     * Handle density altitude remarks.
+     * Format: DENSITY ALT ####FT
+     * <p>
+     * Example: DENSITY ALT 1500FT → 1500 feet density altitude
+     *
+     * @param remarksText remaining remarks text to process
+     * @param remarks     the remarks builder to populate
+     * @return the remaining text after processing (never null)
+     */
+    private String handleDensityAltitudeSequential(String remarksText, NoaaMetarRemarks.Builder remarks) {
+        if (remarksText == null || remarksText.trim().isEmpty()) {
+            return remarksText != null ? remarksText : "";
+        }
+
+        String remaining = remarksText.trim();
+        Matcher matcher = DENSITY_ALTITUDE_PATTERN.matcher(remaining);
+
+        if (matcher.find() && matcher.start() == 0) {
+            try {
+                int densityAlt = Integer.parseInt(matcher.group("denalt"));
+                remarks.densityAltitudeFeet(densityAlt);
+
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Density altitude: {}FT", densityAlt);
+                }
+            } catch (NumberFormatException e) {
+                LOGGER.warn("Invalid density altitude value in remarks: {}", matcher.group(), e);
+            }
+
+            remaining = remaining.substring(matcher.end()).trim();
+        }
+
+        return remaining;
+    }
+
+    /**
      * Handle hail size remark for sequential parsing.
      * <p>
      * Format: GR followed by size in inches
@@ -1829,7 +1867,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * the format is identical (fractions, mixed numbers, whole numbers).
      *
      * @param remarksText the remaining remarks text to process
-     * @param remarks the remarks builder to populate
+     * @param remarks     the remarks builder to populate
      * @return the remaining text after this remark is processed
      */
     private String handleHailSizeSequential(String remarksText, NoaaMetarRemarks.Builder remarks) {
@@ -1906,7 +1944,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * This method will parse all chained events in a single pass.
      *
      * @param remarksText the remaining remarks text to process
-     * @param remarks the remarks builder to populate
+     * @param remarks     the remarks builder to populate
      * @return the remaining text after all chained events are processed
      */
     private String handleWeatherEventsSequential(String remarksText, NoaaMetarRemarks.Builder remarks) {
@@ -2039,7 +2077,8 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
     /**
      * Helper record to return hour and minute components.
      */
-    private record TimeComponents(Integer hour, Integer minute) {}
+    private record TimeComponents(Integer hour, Integer minute) {
+    }
 
     /**
      * Parse time digits which can be either 2 digits (mm) or 4 digits (hhmm).
@@ -2092,10 +2131,10 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * - Precipitation + obscuration (e.g., "RABR")
      * - Just obscuration (e.g., "BR", "FG")
      *
-     * @param descriptor Weather descriptor (may be null)
+     * @param descriptor    Weather descriptor (may be null)
      * @param precipitation Weather precipitation (may be null)
-     * @param obscuration Weather obscuration (may be null)
-     * @param other Other weather phenomena (may be null)
+     * @param obscuration   Weather obscuration (may be null)
+     * @param other         Other weather phenomena (may be null)
      * @return Combined weather code, or empty string if all are null/empty
      */
     private String buildWeatherCodeFromExistingGroups(
@@ -2141,7 +2180,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * Multiple occurrences can be present (e.g., "TS SE CB W").
      *
      * @param remarksText the remaining remarks text to process
-     * @param remarks the remarks builder to populate
+     * @param remarks     the remarks builder to populate
      * @return the remaining text after all cloud locations are processed
      */
     private String handleThunderstormLocationSequential(String remarksText, NoaaMetarRemarks.Builder remarks) {
@@ -2229,7 +2268,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * <p>Note: This remark appears at most once per METAR.
      *
      * @param remarksText the remaining remarks text to process
-     * @param remarks the remarks builder to populate
+     * @param remarks     the remarks builder to populate
      * @return the remaining text after pressure tendency is processed
      */
     private String handlePressureTendencySequential(String remarksText, NoaaMetarRemarks.Builder remarks) {
@@ -2300,7 +2339,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * - 21001 → Minimum: -0.1°C
      *
      * @param remarksText remaining remarks text to process
-     * @param remarks the remarks builder to populate
+     * @param remarks     the remarks builder to populate
      * @return the remaining text after processing
      */
     private String handle6HourMaxMinTemperatureSequential(String remarksText, NoaaMetarRemarks.Builder remarks) {
@@ -2361,9 +2400,9 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
     /**
      * Add parsed 6-hour temperature to appropriate remarks field.
      *
-     * @param type temperature type ("1" = max, "2" = min)
+     * @param type        temperature type ("1" = max, "2" = min)
      * @param temperature the parsed temperature
-     * @param remarks the remarks builder to populate
+     * @param remarks     the remarks builder to populate
      */
     private void add6HourTemperatureToRemarks(String type, Temperature temperature, NoaaMetarRemarks.Builder remarks) {
         if ("1".equals(type)) {
@@ -2394,7 +2433,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * - 400001000 → Max: 0.0°C, Min: -0.0°C
      *
      * @param remarksText remaining remarks text to process
-     * @param remarks the remarks builder to populate
+     * @param remarks     the remarks builder to populate
      * @return the remaining text after processing
      */
     private String handle24HourMaxMinTemperatureSequential(String remarksText, NoaaMetarRemarks.Builder remarks) {
@@ -2491,7 +2530,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * - CIG 020V035 → 2000-3500 feet
      *
      * @param remarksText remaining remarks text to process
-     * @param remarks the remarks builder to populate
+     * @param remarks     the remarks builder to populate
      * @return the remaining text after processing
      */
     private String handleVariableCeilingSequential(String remarksText, NoaaMetarRemarks.Builder remarks) {
@@ -2544,7 +2583,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * to avoid matching variable ceiling patterns (e.g., CIG 005V010).
      *
      * @param remarksText remaining remarks text to process
-     * @param remarks the remarks builder to populate
+     * @param remarks     the remarks builder to populate
      * @return the remaining text after processing
      */
     private String handleCeilingSecondSiteSequential(String remarksText, NoaaMetarRemarks.Builder remarks) {
@@ -2594,7 +2633,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * Multiple layers can be present: FEW FG 000 SCT FU 010
      *
      * @param remarksText remaining remarks text to process
-     * @param remarks the remarks builder to populate
+     * @param remarks     the remarks builder to populate
      * @return the remaining text after processing
      */
     private String handleObscurationSequential(String remarksText, NoaaMetarRemarks.Builder remarks) {
@@ -2650,7 +2689,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * Multiple cloud types can be present: SC1 AC2 CI
      *
      * @param remarksText remaining remarks text to process
-     * @param remarks the remarks builder to populate
+     * @param remarks     the remarks builder to populate
      * @return the remaining text after processing (never null)
      */
     private String handleCloudTypeSequential(String remarksText, NoaaMetarRemarks.Builder remarks) {
@@ -2677,10 +2716,10 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
     /**
      * Process a single cloud type pattern match.
      *
-     * @param matcher the pattern matcher (must not be null)
-     * @param matchEnd the end position of the match
+     * @param matcher   the pattern matcher (must not be null)
+     * @param matchEnd  the end position of the match
      * @param remaining the remaining text (must not be null)
-     * @param remarks the remarks builder (must not be null)
+     * @param remarks   the remarks builder (must not be null)
      * @return the remaining text after processing this match (never null)
      */
     private String processCloudTypeMatch(Matcher matcher, int matchEnd, String remaining,
@@ -2764,7 +2803,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
     /**
      * Determine location and movement from pattern groups.
      *
-     * @param verb the verb group (may be null)
+     * @param verb              the verb group (may be null)
      * @param directionMovement the movement direction (may be null)
      * @param directionLocation the location qualifier (may be null)
      * @return array with [location, movement] - never null, but elements may be null
@@ -2800,7 +2839,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
      * Handles: RVRNO, PWINO, PNO, FZRANO, TSNO, VISNO [LOC], CHINO [LOC], $
      *
      * @param remarksText the remaining remarks text
-     * @param remarks the remarks builder
+     * @param remarks     the remarks builder
      * @return remaining text after processing
      */
     private String handleAutomatedMaintenanceSequential(String remarksText,

--- a/noakweather-platform/weather-processing/src/main/java/weather/processing/parser/noaa/RegExprConst.java
+++ b/noakweather-platform/weather-processing/src/main/java/weather/processing/parser/noaa/RegExprConst.java
@@ -361,7 +361,7 @@ public final class RegExprConst {
      * Example: "DENSITY ALT 800FT"
      */
     public static final Pattern DENSITY_ALTITUDE_PATTERN = Pattern.compile(
-            "^(?<type>DENSITY ALT) (?<denalt>\\d{1,5})(?<units>FT)\\s+"
+            "^(?<type>DENSITY ALT) (?<denalt>\\d{1,5})(?<units>FT)(?=\\s|$)"
     );
 
     /**
@@ -372,7 +372,7 @@ public final class RegExprConst {
      */
     @SuppressWarnings("java:S5843") // Complex regex required for okta cloud format
     public static final Pattern CLOUD_OKTA_PATTERN = Pattern.compile(
-            "^(?<intensity>MDT\\s+)?(?<cloud>(TCU|CU|CF|ST|SC|SF(?!C\\s+VIS)|NS|AS|AC|CS|CC|CI))(?<okta>[1-8](?=\\s|$))?((\\s*(?<verb>MOVG)\\s*(?<dirm>[NSEW][EW]?))|(\\s+(?<direction>OHD-ALQDS|ALQDS|OHD|TR)))?"
+            "^(?<intensity>MDT\\s+)?(?<cloud>(TCU|ACSL|ACC|CU|CF|ST|SC|SF(?!C\\s+VIS)|NS|AS|AC|CS|CC|CI))(?<okta>[1-8](?=\\s|$|[A-Z]))?((\\s*(?<verb>MOVG)\\s*(?<dirm>[NSEW][EW]?))|(\\s+(?<direction>OHD-ALQDS|ALQDS|OHD|TR)))?"
 
     );
 

--- a/noakweather-platform/weather-processing/src/test/java/weather/processing/parser/noaa/NoaaMetarParserTest.java
+++ b/noakweather-platform/weather-processing/src/test/java/weather/processing/parser/noaa/NoaaMetarParserTest.java
@@ -19,6 +19,7 @@ package weather.processing.parser.noaa;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.*;
 import weather.model.NoaaMetarData;
 import weather.model.NoaaWeatherData;
 import weather.model.components.*;
@@ -28,9 +29,6 @@ import weather.model.enums.PressureUnit;
 import weather.model.enums.SkyCoverage;
 import weather.processing.parser.common.ParseResult;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.jupiter.params.provider.CsvSource;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -43,14 +41,14 @@ import static org.assertj.core.api.Assertions.within;
 /**
  * Comprehensive tests for NoaaMetarParser.
  * Tests parsing logic with real METAR examples and edge cases.
- * 
+ *
  * @author bclasky1539
  *
  */
 class NoaaMetarParserTest {
-    
+
     private NoaaMetarParser parser;
-    
+
     @BeforeEach
     void setUp() {
         parser = new NoaaMetarParser();
@@ -87,15 +85,15 @@ class NoaaMetarParserTest {
     void testGetSourceType() {
         assertEquals("NOAA_METAR", parser.getSourceType());
     }
-    
+
     @Test
     @DisplayName("Should identify valid METAR data")
     void testCanParseValidMetar() {
         String metar = "METAR KJFK 251651Z 28016KT 10SM FEW250 22/12 A3015";
-        
+
         assertTrue(parser.canParse(metar));
     }
-    
+
     @Test
     @DisplayName("Should reject non-METAR data")
     void testCanParseInvalidData() {
@@ -103,82 +101,82 @@ class NoaaMetarParserTest {
         assertFalse(parser.canParse("This is not METAR data"));
         assertFalse(parser.canParse(""));
     }
-    
+
     @Test
     @DisplayName("Should reject null data")
     void testCanParseNull() {
         assertFalse(parser.canParse(null));
     }
-    
+
     @Test
     @DisplayName("Should reject empty data")
     void testCanParseEmpty() {
         assertFalse(parser.canParse(""));
         assertFalse(parser.canParse("   "));
     }
-    
+
     @Test
     @DisplayName("Should parse valid METAR successfully")
     void testParseValidMetar() {
         String metar = "METAR KJFK 251651Z 28016KT 10SM FEW250 22/12 A3015 RMK AO2 SLP210";
-        
+
         ParseResult<NoaaWeatherData> result = parser.parse(metar);
-        
+
         assertTrue(result.isSuccess());
         assertTrue(result.getData().isPresent());
-        
+
         NoaaWeatherData data = result.getData().get();
         assertEquals("KJFK", data.getStationId());
         assertEquals("METAR", data.getReportType());
         assertEquals(metar, data.getRawText());
         assertNotNull(data.getObservationTime());
     }
-    
+
     @Test
     @DisplayName("Should parse METAR with minimal data")
     void testParseMinimalMetar() {
         String metar = "METAR KLAX 251651Z";
-        
+
         ParseResult<NoaaWeatherData> result = parser.parse(metar);
-        
+
         assertTrue(result.isSuccess());
         NoaaWeatherData data = extractData(result);
         assertEquals("KLAX", data.getStationId());
     }
-    
+
     @Test
     @DisplayName("Should parse METAR with different station codes")
     void testParseVariousStations() {
         String[] stations = {"KJFK", "KLAX", "KORD", "KATL", "KDFW"};
-        
+
         for (String station : stations) {
             String metar = "METAR " + station + " 251651Z 28016KT 10SM";
             ParseResult<NoaaWeatherData> result = parser.parse(metar);
-            
+
             assertTrue(result.isSuccess());
             NoaaWeatherData data = extractData(result);
             assertEquals(station, data.getStationId());
         }
     }
-    
+
     @ParameterizedTest
     @NullAndEmptySource
     @ValueSource(strings = {"   ", "  \t  ", "\n", "\r\n"})
     @DisplayName("Should fail when parsing invalid input")
     void testParseInvalidInput(String invalidInput) {
         ParseResult<NoaaWeatherData> result = parser.parse(invalidInput);
-    
+
         assertTrue(result.isFailure());
         assertEquals("Raw data cannot be null or empty", result.getErrorMessage());
     }
-    
+
     @Test
     @DisplayName("Should fail when data is not METAR")
     void testParseNonMetarData() {
         String taf = "TAF KJFK 251651Z 2517/2618 28016KT P6SM";
-        
+
         ParseResult<NoaaWeatherData> result = parser.parse(taf);
-        
+
         assertTrue(result.isFailure());
         assertEquals("Data is not a valid METAR report", result.getErrorMessage());
     }
@@ -193,103 +191,103 @@ class NoaaMetarParserTest {
         assertTrue(result.isFailure());
         assertEquals("Failed to parse METAR data: Could not extract station ID from METAR", result.getErrorMessage());
     }
-    
+
     @Test
     @DisplayName("Should fail when station ID is invalid format")
     void testParseInvalidStationId() {
         String invalidMetar = "METAR K1X 251651Z 28016KT"; // Only 3 chars
-        
+
         ParseResult<NoaaWeatherData> result = parser.parse(invalidMetar);
-        
+
         assertTrue(result.isFailure());
         assertEquals("Failed to parse METAR data: Could not extract station ID from METAR", result.getErrorMessage());
     }
 
     @ParameterizedTest
     @CsvSource({
-        "'METAR  KJFK  251651Z  28016KT  10SM', KJFK",
-        "'METAR KORD 251651Z VRB03KT 10SM FEW250', KORD",
-        "'METAR PANC 251651Z 28016KT 10SM M05/M12 A3015', PANC"
+            "'METAR  KJFK  251651Z  28016KT  10SM', KJFK",
+            "'METAR KORD 251651Z VRB03KT 10SM FEW250', KORD",
+            "'METAR PANC 251651Z 28016KT 10SM M05/M12 A3015', PANC"
     })
     @DisplayName("Should parse METAR with various formats and extract correct station ID")
     void testParseMetarVariousFormats(String metar, String expectedStationId) {
         ParseResult<NoaaWeatherData> result = parser.parse(metar);
-    
+
         assertTrue(result.isSuccess());
         NoaaWeatherData data = extractData(result);
         assertEquals(expectedStationId, data.getStationId());
     }
-    
+
     @Test
     @DisplayName("Should trim raw data when storing")
     void testRawDataIsTrimmed() {
         String metar = "  METAR KJFK 251651Z 28016KT  ";
-        
+
         ParseResult<NoaaWeatherData> result = parser.parse(metar);
-        
+
         assertTrue(result.isSuccess());
         NoaaWeatherData data = extractData(result);
         assertEquals(metar.trim(), data.getRawText());
     }
-    
+
     @Test
     @DisplayName("Should parse real-world METAR example - JFK")
     void testParseRealWorldJFK() {
         String metar = "METAR KJFK 121851Z 24008KT 10SM FEW250 23/14 A3012 RMK AO2 SLP201 T02330139";
-        
+
         ParseResult<NoaaWeatherData> result = parser.parse(metar);
-        
+
         assertTrue(result.isSuccess());
         NoaaWeatherData data = extractData(result);
         assertEquals("KJFK", data.getStationId());
         assertEquals("METAR", data.getReportType());
     }
-    
+
     @Test
     @DisplayName("Should parse real-world METAR example - LAX")
     void testParseRealWorldLAX() {
         String metar = "METAR KLAX 121853Z 26008KT 10SM FEW015 SCT250 21/16 A2990 RMK AO2 SLP127";
-        
+
         ParseResult<NoaaWeatherData> result = parser.parse(metar);
-        
+
         assertTrue(result.isSuccess());
         NoaaWeatherData data = extractData(result);
         assertEquals("KLAX", data.getStationId());
     }
- 
+
     @Test
     @DisplayName("Should parse METAR with remarks section")
     void testParseWithRemarks() {
         String metar = "METAR KATL 251651Z 28016KT 10SM FEW250 22/12 A3015 RMK AO2 SLP210 T02220117";
-        
+
         ParseResult<NoaaWeatherData> result = parser.parse(metar);
-        
+
         assertTrue(result.isSuccess());
         NoaaWeatherData data = extractData(result);
         assertTrue(data.getRawText().contains("RMK"));
     }
-    
+
     @Test
     @DisplayName("Should set observation time when parsing")
     void testObservationTimeIsSet() {
         String metar = "METAR KJFK 251651Z 28016KT 10SM";
-        
+
         ParseResult<NoaaWeatherData> result = parser.parse(metar);
-        
+
         assertTrue(result.isSuccess());
         NoaaWeatherData data = extractData(result);
         assertNotNull(data.getObservationTime());
     }
-    
+
     @Test
     @DisplayName("Should handle parser internal exceptions gracefully")
     void testExceptionHandling() {
         // This would require mocking to truly test exception handling
         // For now, we verify that malformed data doesn't crash the parser
         String malformed = "METAR";
-        
+
         ParseResult<NoaaWeatherData> result = parser.parse(malformed);
-        
+
         assertTrue(result.isFailure());
         assertNotNull(result.getErrorMessage());
     }
@@ -2100,7 +2098,7 @@ class NoaaMetarParserTest {
         assertEquals(AutomatedStationType.AO2, data.getRemarks().automatedStationType());
 
         // SLP121 should be parsed
-        assertNotNull(data.getRemarks().seaLevelPressure(),"Sea level pressure should be parsed");
+        assertNotNull(data.getRemarks().seaLevelPressure(), "Sea level pressure should be parsed");
         assertEquals(1012.1, data.getRemarks().seaLevelPressure().toHectopascals(), 0.1,
                 "SLP121 should decode to 1012.1 hPa");
 
@@ -2183,10 +2181,10 @@ class NoaaMetarParserTest {
         assertNotNull(data.getRemarks(), "Remarks should not be null");
 
         // No AO type
-        assertNull(data.getRemarks().automatedStationType(),"Automated station type should be null");
+        assertNull(data.getRemarks().automatedStationType(), "Automated station type should be null");
 
         // SLP210 should be parsed
-        assertNotNull(data.getRemarks().seaLevelPressure(),"Sea level pressure should be parsed");
+        assertNotNull(data.getRemarks().seaLevelPressure(), "Sea level pressure should be parsed");
         assertEquals(1021.0, data.getRemarks().seaLevelPressure().toHectopascals(), 0.1,
                 "SLP210 should decode to 1021.0 hPa");
 
@@ -2268,7 +2266,7 @@ class NoaaMetarParserTest {
         assertEquals(AutomatedStationType.AO2, data.getRemarks().automatedStationType());
 
         // SLP201 should be parsed
-        assertNotNull(data.getRemarks().seaLevelPressure(),"Sea level pressure should be parsed");
+        assertNotNull(data.getRemarks().seaLevelPressure(), "Sea level pressure should be parsed");
         assertEquals(1020.1, data.getRemarks().seaLevelPressure().toHectopascals(), 0.1,
                 "SLP201 should decode to 1020.1 hPa");
 
@@ -2291,10 +2289,10 @@ class NoaaMetarParserTest {
         assertNotNull(data.getRemarks());
 
         // No AO type
-        assertNull(data.getRemarks().automatedStationType(),"Should have no automated station type");
+        assertNull(data.getRemarks().automatedStationType(), "Should have no automated station type");
 
         // SLP210 should be parsed
-        assertNotNull(data.getRemarks().seaLevelPressure(),"Sea level pressure should be parsed");
+        assertNotNull(data.getRemarks().seaLevelPressure(), "Sea level pressure should be parsed");
         assertEquals(1021.0, data.getRemarks().seaLevelPressure().toHectopascals(), 0.1,
                 "SLP210 should decode to 1021.0 hPa");
 
@@ -3357,7 +3355,7 @@ class NoaaMetarParserTest {
         assertNotNull(varVis.maximumVisibility(), "Maximum visibility should not be null: " + scenario);
         Double maxSM = varVis.maximumVisibility().toStatuteMiles();
         assertNotNull(maxSM, "Maximum visibility in SM should not be null: " + scenario);
-        assertEquals(expectedMax, maxSM, 0.01,"Maximum visibility mismatch: " + scenario);
+        assertEquals(expectedMax, maxSM, 0.01, "Maximum visibility mismatch: " + scenario);
 
         // Verify direction and location (empty string means null)
         if (!expectedDir.isEmpty()) {
@@ -7216,10 +7214,6 @@ class NoaaMetarParserTest {
         assertThat(fog.isGroundLevel()).isTrue();
     }
 
-    // ADD this test to verify sky conditions in main body don't interfere with obscuration in remarks
-
-    // ADD this test to verify sky conditions and obscuration layers don't interfere
-
     @Test
     @DisplayName("Should distinguish sky conditions from obscuration layers")
     void testParseObscurationLayer_WithSkyConditionsSameKeyword() {
@@ -7456,7 +7450,7 @@ class NoaaMetarParserTest {
 
     @Test
     @DisplayName("Should parse real-world METAR with cloud types - CYYZ example")
-    void testParseCloudType_RealWorld_CYYZ() {
+    void testParseCloudType_RealWorld_CYYZ_Spaced() {
         // Real METAR from CYYZ - NOTE: "TCU4AC1AC2" is a chained cloud type format
         // Our parser expects space-separated cloud types like "TCU4 AC1 AC2"
         String metar = "METAR CYYZ 052200Z 16008KT 15SM SCT065TCU BKN080 BKN160 25/18 A2976 RMK TCU4 AC1 AC2";
@@ -7508,6 +7502,174 @@ class NoaaMetarParserTest {
         assertThat(scTr.cloudType()).isEqualTo("SC");
         assertThat(scTr.location()).isEqualTo("TR");
         assertThat(scTr.isTrace()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Should parse chained cloud types with no separator - two codes")
+    void testParseCloudType_Chained_TwoCodes() {
+        String metar = "METAR CYYZ 020000Z 07005KT 10SM FEW100 FEW260 22/20 A2995 RMK AC1CI1";
+
+        ParseResult<NoaaWeatherData> result = parser.parse(metar);
+
+        assertTrue(result.isSuccess());
+        NoaaMetarData data = extractMetarData(result);
+
+        assertThat(data.getRemarks()).isNotNull();
+        assertThat(data.getRemarks().cloudTypes()).hasSize(2);
+
+        CloudType ac = data.getRemarks().cloudTypes().get(0);
+        assertThat(ac.cloudType()).isEqualTo("AC");
+        assertThat(ac.oktas()).isEqualTo(1);
+
+        CloudType ci = data.getRemarks().cloudTypes().get(1);
+        assertThat(ci.cloudType()).isEqualTo("CI");
+        assertThat(ci.oktas()).isEqualTo(1);
+
+        assertThat(data.getRemarks().freeText()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should parse chained cloud types with three-letter code - ACC")
+    void testParseCloudType_Chained_ThreeLetterCode() {
+        String metar = "METAR CYYZ 020000Z 07005KT 10SM FEW100 FEW260 22/20 A2995 RMK ACC1CI1";
+
+        ParseResult<NoaaWeatherData> result = parser.parse(metar);
+
+        assertTrue(result.isSuccess());
+        NoaaMetarData data = extractMetarData(result);
+
+        assertThat(data.getRemarks()).isNotNull();
+        assertThat(data.getRemarks().cloudTypes()).hasSize(2);
+
+        CloudType acc = data.getRemarks().cloudTypes().get(0);
+        assertThat(acc.cloudType()).isEqualTo("ACC");
+        assertThat(acc.oktas()).isEqualTo(1);
+
+        CloudType ci = data.getRemarks().cloudTypes().get(1);
+        assertThat(ci.cloudType()).isEqualTo("CI");
+        assertThat(ci.oktas()).isEqualTo(1);
+
+        assertThat(data.getRemarks().freeText()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should parse chained cloud types with ACSL")
+    void testParseCloudType_Chained_ACSL() {
+        String metar = "METAR CYYZ 020000Z 07005KT 10SM FEW100 FEW260 22/20 A2995 RMK ACSL2CI1";
+
+        ParseResult<NoaaWeatherData> result = parser.parse(metar);
+
+        assertTrue(result.isSuccess());
+        NoaaMetarData data = extractMetarData(result);
+
+        assertThat(data.getRemarks()).isNotNull();
+        assertThat(data.getRemarks().cloudTypes()).hasSize(2);
+
+        CloudType acsl = data.getRemarks().cloudTypes().get(0);
+        assertThat(acsl.cloudType()).isEqualTo("ACSL");
+        assertThat(acsl.oktas()).isEqualTo(2);
+
+        CloudType ci = data.getRemarks().cloudTypes().get(1);
+        assertThat(ci.cloudType()).isEqualTo("CI");
+        assertThat(ci.oktas()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("Should parse three chained cloud types - CYVR example")
+    void testParseCloudType_Chained_ThreeCodes() {
+        // Real METAR from CYVR: SC5AC1AC1
+        String metar = "METAR CYVR 020000Z 11011G16KT 30SM BKN061 BKN071 BKN140 19/13 A2976 RMK SC5AC1AC1";
+
+        ParseResult<NoaaWeatherData> result = parser.parse(metar);
+
+        assertTrue(result.isSuccess());
+        NoaaMetarData data = extractMetarData(result);
+
+        assertThat(data.getRemarks()).isNotNull();
+        assertThat(data.getRemarks().cloudTypes()).hasSize(3);
+
+        CloudType sc = data.getRemarks().cloudTypes().get(0);
+        assertThat(sc.cloudType()).isEqualTo("SC");
+        assertThat(sc.oktas()).isEqualTo(5);
+
+        CloudType ac1 = data.getRemarks().cloudTypes().get(1);
+        assertThat(ac1.cloudType()).isEqualTo("AC");
+        assertThat(ac1.oktas()).isEqualTo(1);
+
+        CloudType ac2 = data.getRemarks().cloudTypes().get(2);
+        assertThat(ac2.cloudType()).isEqualTo("AC");
+        assertThat(ac2.oktas()).isEqualTo(1);
+
+        assertThat(data.getRemarks().freeText()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should parse chained cloud types followed by other remarks - CYYZ real-world")
+    void testParseCloudType_Chained_WithFollowingRemarks() {
+        // The actual UAT finding: ACC1CI1 followed by SLP - confirms SLP is no
+        // longer blocked by a stuck cloud-code match after the Bug #1 fix
+        String metar = "METAR CYYZ 020000Z 07005KT 10SM FEW100 FEW260 22/20 A2995 RMK ACC1CI1 SLP142";
+
+        ParseResult<NoaaWeatherData> result = parser.parse(metar);
+
+        assertTrue(result.isSuccess());
+        NoaaMetarData data = extractMetarData(result);
+
+        assertThat(data.getRemarks().cloudTypes()).hasSize(2);
+        assertThat(data.getRemarks().cloudTypes().get(0).cloudType()).isEqualTo("ACC");
+        assertThat(data.getRemarks().cloudTypes().get(1).cloudType()).isEqualTo("CI");
+
+        assertThat(data.getRemarks().seaLevelPressure()).isNotNull();
+        assertThat(data.getRemarks().freeText()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should parse real-world METAR with chained (no-space) cloud types - CYYZ example")
+    void testParseCloudType_RealWorld_CYYZ_Chained() {
+        // Same cloud types as the spaced-form test above, but reported with no
+        // separator at all - remarks formatting varies by source/station
+        String metar = "METAR CYYZ 052200Z 16008KT 15SM SCT065TCU BKN080 BKN160 25/18 A2976 RMK TCU4AC1AC2";
+
+        ParseResult<NoaaWeatherData> result = parser.parse(metar);
+
+        assertTrue(result.isSuccess());
+        NoaaMetarData data = extractMetarData(result);
+
+        assertThat(data.getStationId()).isEqualTo("CYYZ");
+        assertThat(data.getRemarks().cloudTypes()).hasSize(3);
+
+        CloudType tcu = data.getRemarks().cloudTypes().get(0);
+        assertThat(tcu.cloudType()).isEqualTo("TCU");
+        assertThat(tcu.oktas()).isEqualTo(4);
+
+        CloudType ac1 = data.getRemarks().cloudTypes().get(1);
+        assertThat(ac1.cloudType()).isEqualTo("AC");
+        assertThat(ac1.oktas()).isEqualTo(1);
+
+        CloudType ac2 = data.getRemarks().cloudTypes().get(2);
+        assertThat(ac2.cloudType()).isEqualTo("AC");
+        assertThat(ac2.oktas()).isEqualTo(2);
+
+        assertThat(data.getRemarks().freeText()).isNull();
+    }
+
+    // ========== DENSITY ALTITUDE PARSING TESTS ==========
+
+    @ParameterizedTest
+    @CsvSource({
+            "1500, 'METAR CYYZ 020000Z 07005KT 10SM FEW100 FEW260 22/20 A2995 RMK SLP142 DENSITY ALT 1500FT'",
+            "700,  'METAR CYVR 020000Z 24008KT 15SM FEW040 SCT100 18/12 A2998 RMK SLP079 DENSITY ALT 700FT'",
+            "800,  'METAR CYUL 020000Z 32010KT 10SM SCT050 BKN090 15/08 A2985 RMK SLP165 DENSITY ALT 800FT'"
+    })
+    @DisplayName("Should parse density altitude remark - real-world (Issue #57)")
+    void testParseDensityAltitude(int expectedDensityAltFeet, String metar) {
+        ParseResult<NoaaWeatherData> result = parser.parse(metar);
+
+        assertTrue(result.isSuccess());
+        NoaaMetarData data = extractMetarData(result);
+
+        assertThat(data.getRemarks().densityAltitudeFeet()).isEqualTo(expectedDensityAltFeet);
+        assertThat(data.getRemarks().freeText()).isNull();
     }
 
     // ========== AUTOMATED MAINTENANCE INDICATOR PARSING TESTS ==========

--- a/noakweather-platform/weather-storage/pom.xml
+++ b/noakweather-platform/weather-storage/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.19.0-SNAPSHOT</version>
+        <version>1.19.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-storage</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>weather</groupId>
     <artifactId>noakweather-engineering-pipeline</artifactId>
-    <version>1.19.0-SNAPSHOT</version>
+    <version>1.19.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>NoakWeather Engineering Pipeline Root</name>


### PR DESCRIPTION
#53, #57

Bump version to 1.19.1-SNAPSHOT.

- CloudType's VALID_CLOUD_TYPES was missing ACC and ACSL despite CLOUD_OKTA_PATTERN matching them, causing silent construction failures that corrupted downstream remarks parsing (e.g. SLP swallowed into freeText). Added ACC/ACSL to the whitelist and description switch, broadened the okta lookahead to support chained no-space cloud codes (AC1AC1CI1), and reordered the cloud type alternation so ACC/ACSL match before the shorter AC prefix. (#53)

- DENSITY_ALTITUDE_PATTERN existed but was unused and had a trailing-whitespace bug preventing it from matching when the remark was the last token in the string. Fixed the pattern, added handleDensityAltitudeSequential(), wired into handleRemarks(), and added densityAltitudeFeet to NoaaMetarRemarks (record/builder/isEmpty/toString). (#57)

- Added parameterized real-world regression tests (CYYZ, CYVR, CYUL) for chained cloud types and density altitude.

- Updated 21 direct NoaaMetarRemarks constructor call sites in NoaaMetarRemarksTest.java for the new 28-arg constructor.

Full reactor build (wethb.sh + wetht.sh) passing across all modules.

#53 and #57 remain Pending UAT, not closed, pending a full UAT sweep re-run against the worldwide station corpus.