### PR TITLE
Fix present weather placeholders, add secondary altimeter and wind-at-location remarks

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -71,15 +71,12 @@ jobs:
             -Dsonar.projectName="Noakweather Engineering Pipeline" \
             -Dsonar.java.source=${{ matrix.java-version }}
 
-      # TEMPORARY DEBUG STEP - remove once report-task.txt path is confirmed
-      - name: Debug - list scanner working directory
-        if: matrix.java-version == 21
-        run: find noakweather-platform -iname "report-task.txt" 2>/dev/null || echo "report-task.txt not found anywhere under noakweather-platform"
-
       # Only poll/report the Quality Gate once per PR (Java 21 leg)
       - name: SonarQube Quality Gate Check
         if: matrix.java-version == 21
         uses: sonarsource/sonarqube-quality-gate-action@master
         timeout-minutes: 5
+        with:
+          scanMetadataReportFile: noakweather-platform/target/sonar/report-task.txt
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -71,6 +71,11 @@ jobs:
             -Dsonar.projectName="Noakweather Engineering Pipeline" \
             -Dsonar.java.source=${{ matrix.java-version }}
 
+      # TEMPORARY DEBUG STEP - remove once report-task.txt path is confirmed
+      - name: Debug - list scanner working directory
+        if: matrix.java-version == 21
+        run: find noakweather-platform -iname "report-task.txt" 2>/dev/null || echo "report-task.txt not found anywhere under noakweather-platform"
+
       # Only poll/report the Quality Gate once per PR (Java 21 leg)
       - name: SonarQube Quality Gate Check
         if: matrix.java-version == 21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,82 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Version 1.19.2-SNAPSHOT - September 6, 2026
+
+#### UAT Round 1 Remediation - Present Weather, Secondary Altimeter, and Wind at Location (#54, #56, #62)
+
+**Fixed:**
+- **Missing-data slash placeholders misclassified as present weather** (weather-processing) (#54)
+  - `PRESENT_WEATHER_PATTERN`'s precipitation/other groups legitimately accept a
+    bare `/` to support partial-unknown weather codes, but this also allowed a
+    token consisting *entirely* of slashes (`//////`, `/////`) — the ICAO
+    convention for "this whole field is unavailable" — to be parsed as if it
+    were a real weather phenomenon
+  - Added a guard in the shared `handlePresentWeather()` (in
+    `NoaaAviationWeatherParser`, used by both METAR and TAF) to recognize and
+    skip pure-slash tokens rather than constructing a bogus `PresentWeather`
+    entry from the placeholder text
+  - Verified against the real-world MKJP UAT record
+
+**Changed:**
+- **Relocated altimeter/pressure parsing to the shared aviation-weather base
+  class** (weather-processing)
+  - `handleAltimeter()`, `parsePressure()`, and their supporting helpers were
+    previously METAR-only, in `NoaaMetarParser`; moved to
+    `NoaaAviationWeatherParser` so `NoaaTafParser` can inherit the same logic
+    (TAF-side wiring deferred to a later change)
+  - `GROUP_PRESSURE_CHANGE` restored to `private static final` after the move
+    temporarily widened it to a mutable field (SonarCloud java:S116)
+  - Added direct unit tests for the relocated logic in
+    `NoaaAviationWeatherParserTest` (A/Q/QNH/INS formats, value-based
+    heuristic, missing data, OCR `O`→`0` normalization), since prior coverage
+    only existed indirectly through METAR integration tests
+
+**Added:**
+- **Secondary altimeter setting repeated inside remarks** (weather-common,
+  weather-processing) (#56)
+  - Philippines/Taiwan-region METARs (RPLL, RCTP) repeat the altimeter inside
+    `RMK` in US-style inches-of-mercury format (`A####`) as a redundant
+    confirmation of the main body's ICAO hPa reading
+  - Fixed `ALTIMETER_PATTERN`'s trailing mandatory whitespace (same
+    last-token-in-string bug pattern as `DENSITY_ALTITUDE_PATTERN` in #57);
+    replaced with a non-consuming lookahead
+  - Added `secondaryAltimeter` (`Pressure`) field to `NoaaMetarRemarks`,
+    reusing the now-shared `parsePressure()` rather than duplicating
+    conversion logic
+  - Added `handleSecondaryAltimeterSequential()` in `NoaaMetarParser`
+
+- **Wind at a specific location (altitude or runway) reported in remarks**
+  (weather-common, weather-processing) (#62)
+  - Norwegian/Arctic-region METARs (ENSB, ENSD, ENSG, ENSH, ENSR) report wind
+    at a specific altitude (`WIND ####FT ddd(dd)KT`) or a specific runway
+    (`WIND RWY ## ddd(dd)KT`), distinct from surface wind, with multiple
+    entries sometimes chained in the same remarks string
+  - New `WindAtLocation` record (`weather.model.components.remark`) wraps the
+    existing `Wind` value object with an altitude/runway qualifier, avoiding
+    duplication of direction/speed/gust/VRB handling
+  - Added `WIND_AT_LOCATION_PATTERN` to `RegExprConst.java`, matching both
+    qualifier forms and supporting `VRB` direction
+  - Added `List<WindAtLocation> windsAtLocation` to `NoaaMetarRemarks`
+  - Added loop-based `handleWindAtLocationSequential()` /
+    `processWindAtLocationMatch()` in `NoaaMetarParser`, mirroring the
+    established chained-match pattern from `handleCloudTypeSequential`
+
+**Testing:**
+- Added `WindAtLocationTest.java` covering constructor validation, factory
+  methods, `getSummary()`, and equality
+- Added real-world regression tests in `NoaaMetarParserTest` for all five
+  Norwegian UAT stations, including chained runway+altitude and `VRB`
+  direction cases
+- Added builder-level tests in `NoaaMetarRemarksTest` for `secondaryAltimeter`
+  and `windsAtLocation` to close module-level coverage gaps (same class of
+  gap identified and fixed for `densityAltitudeFeet` under #57)
+
+**Notes:**
+- Issues #54, #56, and #62 are marked **Pending UAT** rather than Done —
+  verified via unit tests and code review, not yet confirmed against the full
+  worldwide UAT station set.
+
 ### Version 1.19.1-SNAPSHOT - September 3, 2026
 
 #### UAT Round 1 Remediation - Cloud Type Parsing and Density Altitude (#53, #57)

--- a/noakweather-platform/pom.xml
+++ b/noakweather-platform/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>weather</groupId>
     <artifactId>noakweather-platform</artifactId>
-    <version>1.19.1-SNAPSHOT</version>
+    <version>1.19.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>NoakWeather Engineering Pipeline</name>

--- a/noakweather-platform/weather-analytics/pom.xml
+++ b/noakweather-platform/weather-analytics/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.19.1-SNAPSHOT</version>
+        <version>1.19.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-analytics</artifactId>

--- a/noakweather-platform/weather-common/pom.xml
+++ b/noakweather-platform/weather-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.19.1-SNAPSHOT</version>
+        <version>1.19.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-common</artifactId>

--- a/noakweather-platform/weather-common/src/main/java/weather/model/components/remark/NoaaMetarRemarks.java
+++ b/noakweather-platform/weather-common/src/main/java/weather/model/components/remark/NoaaMetarRemarks.java
@@ -43,6 +43,7 @@ import java.util.stream.Collectors;
  * * @param hourlyTemperature Hourly temperature and dewpoint (T-group)
  * * @param peakWind Peak wind information
  * * @param windShift Wind shift information
+ * * @param windsAtLocation Winds at a location
  * * @param variableVisibility Variable visibility data
  * * @param CeilingSecondSite Ceiling height at second observation site
  * * @param obscurationLayers Obscuration Layer information
@@ -58,6 +59,7 @@ import java.util.stream.Collectors;
  * * @param weatherEvents List of weather events (beginning/ending times)
  * * @param thunderstormLocations List of thunderstorm/cloud locations
  * * @param pressureTendency 3-hour pressure tendency
+ * * @param secondaryAltimeter Secondary altimeter reading
  * * @param sixHourMaxTemperature 6-hour maximum temperature
  * * @param sixHourMinTemperature 6-hour minimum temperature
  * * @param twentyFourHourMaxTemperature 24-hour maximum temperature
@@ -77,6 +79,7 @@ public record NoaaMetarRemarks(
         Temperature preciseDewpoint,
         PeakWind peakWind,
         WindShift windShift,
+        List<WindAtLocation> windsAtLocation,
         VariableVisibility variableVisibility,
         VariableCeiling variableCeiling,
         CeilingSecondSite ceilingSecondSite,
@@ -91,6 +94,7 @@ public record NoaaMetarRemarks(
         List<WeatherEvent> weatherEvents,
         List<ThunderstormLocation> thunderstormLocations,
         PressureTendency pressureTendency,
+        Pressure secondaryAltimeter,
         Temperature sixHourMaxTemperature,
         Temperature sixHourMinTemperature,
         Temperature twentyFourHourMaxTemperature,
@@ -123,10 +127,10 @@ public record NoaaMetarRemarks(
      */
     public static NoaaMetarRemarks empty() {
         return new NoaaMetarRemarks(null, null, null, null,
-                null, null, null, null, null, List.of(),
+                null, null, List.of(), null, null, null, List.of(),
                 List.of(), null, null, null, null,
                 null, null, List.of(), List.of(), null,
-                null, null, null,
+                null, null, null, null,
                 null, null, List.of(), null, null);
     }
 
@@ -142,6 +146,7 @@ public record NoaaMetarRemarks(
                 && preciseDewpoint == null
                 && peakWind == null
                 && windShift == null
+                && (windsAtLocation == null || windsAtLocation.isEmpty())
                 && variableVisibility == null
                 && variableCeiling == null
                 && ceilingSecondSite == null
@@ -156,6 +161,7 @@ public record NoaaMetarRemarks(
                 && (weatherEvents == null || weatherEvents.isEmpty())
                 && (thunderstormLocations == null || thunderstormLocations.isEmpty())
                 && pressureTendency == null
+                && secondaryAltimeter == null
                 && sixHourMaxTemperature == null
                 && sixHourMinTemperature == null
                 && twentyFourHourMaxTemperature == null
@@ -196,6 +202,7 @@ public record NoaaMetarRemarks(
         private Temperature preciseDewpoint;
         private PeakWind peakWind;
         private WindShift windShift;
+        private List<WindAtLocation> windsAtLocation = new ArrayList<>();
         private VariableVisibility variableVisibility;
         private VariableCeiling variableCeiling;
         private CeilingSecondSite ceilingSecondSite;
@@ -210,6 +217,7 @@ public record NoaaMetarRemarks(
         private List<WeatherEvent> weatherEvents = new ArrayList<>();
         private List<ThunderstormLocation> thunderstormLocations = new ArrayList<>();
         private PressureTendency pressureTendency;
+        private Pressure secondaryAltimeter;
         private Temperature sixHourMaxTemperature;
         private Temperature sixHourMinTemperature;
         private Temperature twentyFourHourMaxTemperature;
@@ -286,6 +294,43 @@ public record NoaaMetarRemarks(
          */
         public Builder windShift(WindShift windShift) {
             this.windShift = windShift;
+            return this;
+        }
+
+        /**
+         * Adds a single winds at a location.
+         *
+         * @param windsAtLocation the cloud type to add
+         * @return this builder
+         */
+        public Builder addWindAtLocation(WindAtLocation windsAtLocation) {
+            if (windsAtLocation != null) {
+                this.windsAtLocation.add(windsAtLocation);
+            }
+            return this;
+        }
+
+        /**
+         * Sets the winds at location list.
+         *
+         * @param windsAtLocation the winds at location
+         * @return this builder
+         */
+        public Builder windsAtLocation(List<WindAtLocation> windsAtLocation) {
+            this.windsAtLocation = windsAtLocation != null ? new ArrayList<>(windsAtLocation) : new ArrayList<>();
+            return this;
+        }
+
+        /**
+         * Adds multiple winds at location.
+         *
+         * @param windsAtLocation the winds at location to add
+         * @return this builder
+         */
+        public Builder addWindsAtLocation(List<WindAtLocation> windsAtLocation) {
+            if (windsAtLocation != null) {
+                this.windsAtLocation.addAll(windsAtLocation);
+            }
             return this;
         }
 
@@ -544,6 +589,19 @@ public record NoaaMetarRemarks(
         }
 
         /**
+         * Sets the secondary altimeter setting repeated inside the remarks section.
+         * Common in Philippines/Taiwan-region METARs as a redundant confirmation
+         * of the main body's altimeter reading, in US-style inches of mercury.
+         *
+         * @param secondaryAltimeter the secondary altimeter pressure
+         * @return this builder
+         */
+        public Builder secondaryAltimeter(Pressure secondaryAltimeter) {
+            this.secondaryAltimeter = secondaryAltimeter;
+            return this;
+        }
+
+        /**
          * Set 6-hour maximum temperature.
          *
          * @param sixHourMaxTemperature maximum temperature in 6-hour period
@@ -647,6 +705,7 @@ public record NoaaMetarRemarks(
                     preciseDewpoint,
                     peakWind,
                     windShift,
+                    List.copyOf(windsAtLocation),
                     variableVisibility,
                     variableCeiling,
                     ceilingSecondSite,
@@ -661,6 +720,7 @@ public record NoaaMetarRemarks(
                     List.copyOf(weatherEvents),
                     List.copyOf(thunderstormLocations),
                     pressureTendency,
+                    secondaryAltimeter,
                     sixHourMaxTemperature,
                     sixHourMinTemperature,
                     twentyFourHourMaxTemperature,
@@ -689,6 +749,11 @@ public record NoaaMetarRemarks(
                 t -> String.format(TEMPERATURE_FORMAT, t.celsius()));
         addIfPresent(parts, peakWind, "peakWind", Object::toString);
         addIfPresent(parts, windShift, "windShift", Object::toString);
+        if (windsAtLocation != null && !windsAtLocation.isEmpty()) {
+            parts.add("windsAtLocation=" + windsAtLocation.stream()
+                    .map(WindAtLocation::getSummary)
+                    .collect(Collectors.joining("; ")));
+        }
         addIfPresent(parts, variableVisibility, "variableVisibility", Object::toString);
         addIfPresent(parts, variableCeiling, "variableCeiling", VariableCeiling::getSummary);
         addIfPresent(parts, ceilingSecondSite, "ceilingSecondSite", CeilingSecondSite::getSummary);
@@ -719,6 +784,7 @@ public record NoaaMetarRemarks(
                     .collect(Collectors.joining("; ")));
         }
         addIfPresent(parts, pressureTendency, "pressureTendency", PressureTendency::getSummary);
+        addIfPresent(parts, secondaryAltimeter, "secondaryAltimeter", Pressure::getFormattedValue);
         addIfPresent(parts, sixHourMaxTemperature, "sixHourMaxTemp",
                 t -> String.format(TEMPERATURE_FORMAT, t.celsius()));
         addIfPresent(parts, sixHourMinTemperature, "sixHourMinTemp",

--- a/noakweather-platform/weather-common/src/main/java/weather/model/components/remark/WindAtLocation.java
+++ b/noakweather-platform/weather-common/src/main/java/weather/model/components/remark/WindAtLocation.java
@@ -1,0 +1,97 @@
+package weather.model.components.remark;
+
+import weather.model.components.Wind;
+
+/**
+ * Immutable value object representing wind conditions reported in remarks
+ * at a specific location — either a specific altitude or a specific runway —
+ * distinct from surface wind reported in the main body.
+ * <p>
+ * Common in Norwegian/Arctic-region METARs where surface conditions
+ * (e.g. calm, or a runway-specific reading) differ meaningfully from
+ * conditions at altitude or at a specific runway.
+ * <p>
+ * Examples:
+ * - "WIND 1400FT 23010KT" → WindAtLocation(1400, null, Wind.of(230, 10, "KT"))
+ * - "WIND RWY 26 00000KT" → WindAtLocation(null, "26", Wind.of(0, 0, "KT"))
+ *
+ * @param heightFeet Altitude in feet, or null if this is a runway-specific reading
+ * @param runway     Runway designator (e.g. "26"), or null if this is an altitude reading
+ * @param wind       Wind conditions at that location
+ * @author bclasky1539
+ *
+ */
+public record WindAtLocation(
+        Integer heightFeet,
+        String runway,
+        Wind wind
+) {
+
+    /**
+     * Compact constructor with validation.
+     */
+    public WindAtLocation {
+        if (heightFeet == null && (runway == null || runway.isBlank())) {
+            throw new IllegalArgumentException("Either heightFeet or runway must be provided");
+        }
+        if (heightFeet != null && runway != null) {
+            throw new IllegalArgumentException("Cannot specify both heightFeet and runway");
+        }
+        if (wind == null) {
+            throw new IllegalArgumentException("Wind cannot be null");
+        }
+    }
+
+    /**
+     * Check if this reading is at a specific altitude rather than a runway.
+     *
+     * @return true if this is an altitude-based reading
+     */
+    public boolean isAtAltitude() {
+        return heightFeet != null;
+    }
+
+    /**
+     * Check if this reading is at a specific runway rather than an altitude.
+     *
+     * @return true if this is a runway-based reading
+     */
+    public boolean isAtRunway() {
+        return runway != null;
+    }
+
+    /**
+     * Get a human-readable summary.
+     * Examples: "Wind at 1400ft: 230° at 10 KT", "Wind at RWY 26: CALM"
+     *
+     * @return formatted summary string
+     */
+    public String getSummary() {
+        String location = isAtAltitude() ? heightFeet + "ft" : "RWY " + runway;
+        return "Wind at " + location + ": " + wind.getSummary();
+    }
+
+    // ==================== Factory Methods ====================
+
+    /**
+     * Factory method for a wind reading at a specific altitude.
+     *
+     * @param heightFeet altitude in feet
+     * @param wind wind conditions at that altitude
+     * @return WindAtLocation instance representing an altitude-based reading
+     */
+    public static WindAtLocation atAltitude(int heightFeet, Wind wind) {
+        return new WindAtLocation(heightFeet, null, wind);
+    }
+
+    /**
+     * Factory method for a wind reading at a specific runway.
+     *
+     * @param runway runway designator (e.g. "26")
+     * @param wind wind conditions at that runway
+     * @return WindAtLocation instance representing a runway-based reading
+     */
+    public static WindAtLocation atRunway(String runway, Wind wind) {
+        return new WindAtLocation(null, runway, wind);
+    }
+}

--- a/noakweather-platform/weather-common/src/test/java/weather/model/components/remark/NoaaMetarRemarksTest.java
+++ b/noakweather-platform/weather-common/src/test/java/weather/model/components/remark/NoaaMetarRemarksTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import weather.model.components.Pressure;
 import weather.model.components.Temperature;
 import weather.model.components.Visibility;
+import weather.model.components.Wind;
 import weather.model.enums.AutomatedStationType;
 
 import java.util.ArrayList;
@@ -171,8 +172,8 @@ class NoaaMetarRemarksTest {
                 null, null, null, null, null,
                 null, null, null, null, null,
                 null, null, null, null,
-                null, null, null,
-                null, null, freeText
+                null, null, null, null,
+                null, null, null, freeText
         );
 
         assertEquals(stationType, remarks.automatedStationType());
@@ -229,9 +230,7 @@ class NoaaMetarRemarksTest {
         assertNotEquals(remarks1, remarks2);
     }
 
-    // Add these tests to NoaaMetarRemarksTest.java
-
-// ========== Tests for hasFrontalPassage() ==========
+    // ========== Tests for hasFrontalPassage() ==========
 
     @Test
     void testHasFrontalPassageTrue() {
@@ -263,7 +262,8 @@ class NoaaMetarRemarksTest {
         assertFalse(remarks.hasFrontalPassage());
     }
 
-// ========== Tests for isEmpty() edge cases ==========
+    // ========== Tests for isEmpty() edge cases ==========
+    // ========== Tests for isEmpty() edge cases ==========
 
     @Test
     void testIsEmptyWithOnlySeaLevelPressure() {
@@ -334,7 +334,7 @@ class NoaaMetarRemarksTest {
         assertThat(remarks.freeText()).isNotBlank();
     }
 
-// ========== Tests for record constructor with all field combinations ==========
+    // ========== Tests for record constructor with all field combinations ==========
 
     @Test
     void testRecordConstructorWithPeakWind() {
@@ -343,11 +343,11 @@ class NoaaMetarRemarksTest {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, peakWind,
                 null, null, null, null, null,
-                null, null, null,
+                null, null, null, null,
                 null, null, null, null, null,
                 null, null, null, null,
                 null, null, null,
-                null, null, null
+                null, null, null, null
         );
 
         assertEquals(peakWind, remarks.peakWind());
@@ -360,12 +360,12 @@ class NoaaMetarRemarksTest {
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
-                windShift, null, null, null, null,
+                windShift, null,null, null, null, null,
                 null, null, null,
                 null, null, null, null, null,
                 null, null, null, null,
                 null, null, null,
-                null, null, null
+                null, null, null, null
         );
 
         assertNull(remarks.peakWind());
@@ -396,6 +396,228 @@ class NoaaMetarRemarksTest {
 
         String str = remarks.toString();
         assertTrue(str.contains("windShift"));
+    }
+
+    // ========== WIND AT LOCATION TESTS ==========
+
+    @Test
+    @DisplayName("Should create NoaaMetarRemarks with single wind at altitude")
+    void testBuilder_SingleWindAtAltitude() {
+        WindAtLocation windAtLocation = WindAtLocation.atAltitude(1400, Wind.of(230, 10, "KT"));
+
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .addWindAtLocation(windAtLocation)
+                .build();
+
+        assertThat(remarks.windsAtLocation()).hasSize(1);
+        assertThat(remarks.windsAtLocation().get(0)).isEqualTo(windAtLocation);
+        assertThat(remarks.windsAtLocation().get(0).isAtAltitude()).isTrue();
+        assertThat(remarks.windsAtLocation().get(0).heightFeet()).isEqualTo(1400);
+        assertThat(remarks.isEmpty()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should create NoaaMetarRemarks with single wind at runway (calm, 00000KT)")
+    void testBuilder_SingleWindAtRunway() {
+        WindAtLocation windAtLocation = WindAtLocation.atRunway("26", Wind.of(0, 0, "KT"));
+
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .addWindAtLocation(windAtLocation)
+                .build();
+
+        assertThat(remarks.windsAtLocation()).hasSize(1);
+        assertThat(remarks.windsAtLocation().get(0)).isEqualTo(windAtLocation);
+        assertThat(remarks.windsAtLocation().get(0).isAtRunway()).isTrue();
+        assertThat(remarks.windsAtLocation().get(0).runway()).isEqualTo("26");
+        assertThat(remarks.isEmpty()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should create NoaaMetarRemarks with multiple winds at location")
+    void testBuilder_MultipleWindsAtLocation() {
+        WindAtLocation windAtRunway = WindAtLocation.atRunway("32", Wind.variable(1, "KT"));
+        WindAtLocation windAtAltitude = WindAtLocation.atAltitude(1119, Wind.variable(3, "KT"));
+
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .addWindAtLocation(windAtRunway)
+                .addWindAtLocation(windAtAltitude)
+                .build();
+
+        assertThat(remarks.windsAtLocation()).hasSize(2);
+        assertThat(remarks.windsAtLocation()).containsExactly(windAtRunway, windAtAltitude);
+        assertThat(remarks.isEmpty()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should create NoaaMetarRemarks with windsAtLocation list via bulk setter")
+    void testBuilder_WindsAtLocationList() {
+        List<WindAtLocation> winds = List.of(
+                WindAtLocation.atAltitude(1400, Wind.of(230, 10, "KT")),
+                WindAtLocation.atRunway("26", Wind.of(0, 0, "KT"))
+        );
+
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .windsAtLocation(winds)
+                .build();
+
+        assertThat(remarks.windsAtLocation()).hasSize(2);
+        assertThat(remarks.windsAtLocation()).isEqualTo(winds);
+        assertThat(remarks.isEmpty()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should add multiple winds at location via addWindsAtLocation bulk method")
+    void testBuilder_AddWindsAtLocationBulk() {
+        WindAtLocation wind1 = WindAtLocation.atAltitude(1400, Wind.of(230, 10, "KT"));
+        WindAtLocation wind2 = WindAtLocation.atRunway("26", Wind.of(0, 0, "KT"));
+        List<WindAtLocation> winds = List.of(wind1, wind2);
+
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .addWindsAtLocation(winds)
+                .build();
+
+        assertThat(remarks.windsAtLocation()).hasSize(2);
+        assertThat(remarks.windsAtLocation()).containsExactly(wind1, wind2);
+    }
+
+    @Test
+    @DisplayName("Should handle null windsAtLocation list via bulk setter")
+    void testBuilder_NullWindsAtLocationList() {
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .windsAtLocation(null)
+                .build();
+
+        assertThat(remarks.windsAtLocation()).isEmpty();
+        assertThat(remarks.windsAtLocation()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Should handle empty windsAtLocation list")
+    void testBuilder_EmptyWindsAtLocationList() {
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .windsAtLocation(List.of())
+                .build();
+
+        assertThat(remarks.windsAtLocation()).isEmpty();
+        assertThat(remarks.windsAtLocation()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Should handle null windAtLocation in addWindAtLocation")
+    void testBuilder_AddNullWindAtLocation() {
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .addWindAtLocation(null)
+                .build();
+
+        assertThat(remarks.windsAtLocation()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should handle null list in addWindsAtLocation")
+    void testBuilder_AddWindsAtLocationNull() {
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .addWindsAtLocation(null)
+                .build();
+
+        assertThat(remarks.windsAtLocation()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should make defensive copy of windsAtLocation list")
+    void testBuilder_DefensiveCopyOfWindsAtLocation() {
+        List<WindAtLocation> originalList = new ArrayList<>();
+        originalList.add(WindAtLocation.atAltitude(1400, Wind.of(230, 10, "KT")));
+
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .windsAtLocation(originalList)
+                .build();
+
+        originalList.add(WindAtLocation.atRunway("26", Wind.of(0, 0, "KT")));
+
+        assertThat(remarks.windsAtLocation()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("Should be empty when windsAtLocation is null")
+    void testIsEmptyWithNullWindsAtLocation() {
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .windsAtLocation(null)
+                .build();
+
+        assertThat(remarks.windsAtLocation()).isEmpty();
+        // Note: isEmpty() returns false because List fields are initialized
+    }
+
+    @Test
+    @DisplayName("Should not be empty when only windsAtLocation is present")
+    void testIsEmptyWithOnlyWindsAtLocation() {
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .addWindAtLocation(WindAtLocation.atAltitude(1400, Wind.of(230, 10, "KT")))
+                .build();
+
+        assertFalse(remarks.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should include windsAtLocation in toString()")
+    void testToString_WindsAtLocation() {
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .addWindAtLocation(WindAtLocation.atAltitude(1400, Wind.of(230, 10, "KT")))
+                .build();
+
+        String str = remarks.toString();
+        assertThat(str)
+                .contains("windsAtLocation=")
+                .contains("1400ft");
+    }
+
+    @Test
+    @DisplayName("Should include multiple windsAtLocation with semicolon separator in toString()")
+    void testToString_MultipleWindsAtLocation() {
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .addWindAtLocation(WindAtLocation.atRunway("32", Wind.variable(1, "KT")))
+                .addWindAtLocation(WindAtLocation.atAltitude(1119, Wind.variable(3, "KT")))
+                .build();
+
+        String str = remarks.toString();
+        assertThat(str)
+                .contains("windsAtLocation=")
+                .contains(";")
+                .contains("RWY 32")
+                .contains("1119ft");
+    }
+
+    @Test
+    @DisplayName("Should be equal when windsAtLocation are the same")
+    void testEqualityWithWindsAtLocation() {
+        WindAtLocation windAtLocation = WindAtLocation.atAltitude(1400, Wind.of(230, 10, "KT"));
+
+        NoaaMetarRemarks remarks1 = NoaaMetarRemarks.builder()
+                .automatedStationType(AutomatedStationType.AO2)
+                .addWindAtLocation(windAtLocation)
+                .build();
+
+        NoaaMetarRemarks remarks2 = NoaaMetarRemarks.builder()
+                .automatedStationType(AutomatedStationType.AO2)
+                .addWindAtLocation(windAtLocation)
+                .build();
+
+        assertEquals(remarks1, remarks2);
+        assertEquals(remarks1.hashCode(), remarks2.hashCode());
+    }
+
+    @Test
+    @DisplayName("Should not be equal when windsAtLocation differ")
+    void testInequalityWithDifferentWindsAtLocation() {
+        NoaaMetarRemarks remarks1 = NoaaMetarRemarks.builder()
+                .addWindAtLocation(WindAtLocation.atAltitude(1400, Wind.of(230, 10, "KT")))
+                .build();
+
+        NoaaMetarRemarks remarks2 = NoaaMetarRemarks.builder()
+                .addWindAtLocation(WindAtLocation.atRunway("26", Wind.of(0, 0, "KT")))
+                .build();
+
+        assertNotEquals(remarks1, remarks2);
     }
 
     // ========== Tests for isEmpty() with VariableVisibility ==========
@@ -436,12 +658,12 @@ class NoaaMetarRemarksTest {
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
-                null, varVis, null, null, null,
+                null, null, varVis, null, null, null,
                 null, null, null,
                 null, null, null, null, null,
                 null, null, null, null,
                 null, null, null,
-                null, null, null
+                null, null, null, null
         );
 
         assertEquals(varVis, remarks.variableVisibility());
@@ -642,12 +864,12 @@ class NoaaMetarRemarksTest {
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
-                null, null, null, null, null,
+                null, null, null, null, null, null,
                 null, towerVis, null,
                 null, null, null, null, null,
                 null, null, null, null,
                 null, null, null,
-                null, null, null
+                null, null, null, null
         );
 
         assertEquals(towerVis, remarks.towerVisibility());
@@ -661,12 +883,12 @@ class NoaaMetarRemarksTest {
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
-                null, null, null, null, null,
+                null, null, null, null, null, null,
                 null, null, surfaceVis,
                 null, null, null, null, null,
                 null, null, null, null,
                 null, null, null,
-                null, null, null
+                null, null, null, null
         );
 
         assertNull(remarks.towerVisibility());
@@ -681,12 +903,12 @@ class NoaaMetarRemarksTest {
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
-                null, null, null, null, null,
+                null, null, null, null, null, null,
                 null, towerVis, surfaceVis,
                 null, null, null, null, null,
                 null, null, null, null,
                 null, null, null,
-                null, null, null
+                null, null, null, null
         );
 
         assertEquals(towerVis, remarks.towerVisibility());
@@ -694,7 +916,7 @@ class NoaaMetarRemarksTest {
     }
 
 
-// ========== Tests for builder with Tower/Surface Visibility ==========
+    // ========== Tests for builder with Tower/Surface Visibility ==========
 
     @Test
     @DisplayName("Should build remarks with towerVisibility via builder")
@@ -890,12 +1112,12 @@ class NoaaMetarRemarksTest {
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
-                null, null, null, null, null,
+                null, null, null, null, null, null,
                 null, null, null,
                 hourly, null, null, null, null, null,
                 null, null, null, null,
                 null, null, null, null,
-                null
+                null, null
         );
 
         assertEquals(hourly, remarks.hourlyPrecipitation());
@@ -910,12 +1132,12 @@ class NoaaMetarRemarksTest {
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
-                null, null, null, null, null,
+                null, null, null, null, null, null,
                 null, null, null,
                 null, sixHour, null, null, null, null,
                 null, null, null, null,
                 null, null, null, null,
-                null
+                null, null
         );
 
         assertNull(remarks.hourlyPrecipitation());
@@ -930,12 +1152,12 @@ class NoaaMetarRemarksTest {
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
-                null, null, null, null, null,
+                null, null, null, null, null, null,
                 null, null, null,
                 null, null, twentyFourHour, null, null, null,
                 null, null, null, null,
                 null, null, null, null,
-                null
+                null, null
         );
 
         assertNull(remarks.hourlyPrecipitation());
@@ -952,12 +1174,12 @@ class NoaaMetarRemarksTest {
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
-                null, null, null, null, null,
+                null, null, null, null, null, null,
                 null, null, null,
                 hourly, sixHour, twentyFourHour, null, null, null,
                 null, null, null, null,
                 null, null, null, null,
-                null
+                null, null
         );
 
         assertEquals(hourly, remarks.hourlyPrecipitation());
@@ -1200,12 +1422,12 @@ class NoaaMetarRemarksTest {
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
-                null, null, null, null, null,
+                null, null, null, null, null, null,
                 null, null, null,
                 null, null, null, hailSize, null,
                 null, null, null, null,
                 null, null, null,
-                null, null, null
+                null, null, null, null
         );
 
         assertEquals(hailSize, remarks.hailSize());
@@ -1216,12 +1438,12 @@ class NoaaMetarRemarksTest {
     void testRecordConstructorWithNullHailSize() {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
-                null, null, null, null, null,
+                null, null, null, null, null, null,
                 null, null, null,
                 null, null, null, null, null,
                 null, null, null, null,
                 null, null, null,
-                null, null, null
+                null, null, null, null
         );
 
         assertNull(remarks.hailSize());
@@ -1331,7 +1553,7 @@ class NoaaMetarRemarksTest {
     }
 
 
-// ========== Tests with Different Hail Sizes ==========
+    // ========== Tests with Different Hail Sizes ==========
 
     @Test
     @DisplayName("Should handle severe hail size")
@@ -1419,12 +1641,12 @@ class NoaaMetarRemarksTest {
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
-                null, null, null, null, null,
+                null, null, null, null, null, null,
                 null, null, null,
                 null, null, null, null, null,
                 List.of(location), null, null, null,
                 null, null, null,
-                null, null, null
+                null, null, null, null
         );
 
         assertEquals(1, remarks.thunderstormLocations().size());
@@ -1439,12 +1661,12 @@ class NoaaMetarRemarksTest {
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
-                null, null, null, null, null,
+                null, null, null, null, null, null,
                 null, null, null,
                 null, null, null, null, null,
                 List.of(location1, location2), null, null, null,
                 null, null, null,
-                null, null, null
+                null, null, null, null
         );
 
         assertEquals(2, remarks.thunderstormLocations().size());
@@ -1810,7 +2032,7 @@ class NoaaMetarRemarksTest {
         // Note: isEmpty() returns false because weatherEvents field is set to empty list
     }
 
-// ========== NEW Tests for record constructor with Weather Events ==========
+    // ========== NEW Tests for record constructor with Weather Events ==========
 
     @Test
     @DisplayName("Should create remarks with single weatherEvent via record constructor")
@@ -1819,12 +2041,12 @@ class NoaaMetarRemarksTest {
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
-                null, null, null, null, null,
+                null, null, null, null, null, null,
                 null, null, null,
                 null, null, null, null, List.of(event),
                 null, null, null, null,
                 null, null, null,
-                null, null, null
+                null, null, null, null
         );
 
         assertEquals(1, remarks.weatherEvents().size());
@@ -1839,12 +2061,12 @@ class NoaaMetarRemarksTest {
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
-                null, null, null, null, null,
+                null, null, null, null, null, null,
                 null, null, null,
                 null, null, null, null, List.of(event1, event2),
                 null, null, null, null,
                 null, null, null,
-                null, null, null
+                null, null, null, null
         );
 
         assertEquals(2, remarks.weatherEvents().size());
@@ -2225,12 +2447,12 @@ class NoaaMetarRemarksTest {
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
-                null, null, null, null, null,
+                null, null, null, null, null, null,
                 null, null, null,
                 null, null, null, null, null,
                 null, tendency, null, null,
                 null, null, null,
-                null, null, null
+                null, null, null, null
         );
 
         assertEquals(tendency, remarks.pressureTendency());
@@ -2241,12 +2463,12 @@ class NoaaMetarRemarksTest {
     void testRecordConstructorWithNullPressureTendency() {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
-                null, null, null, null, null,
+                null, null,null, null, null, null,
                 null, null, null,
                 null, null, null, null, null,
                 null, null, null, null,
                 null, null, null,
-                null, null, null
+                null, null, null, null
         );
 
         assertNull(remarks.pressureTendency());
@@ -2317,7 +2539,7 @@ class NoaaMetarRemarksTest {
         assertTrue(str.contains("Pressure tendency") || str.contains("pressureTendency"));
     }
 
-// ========== Tests for equality with Pressure Tendency ==========
+    // ========== Tests for equality with Pressure Tendency ==========
 
     @Test
     @DisplayName("Should be equal when pressureTendency is the same")
@@ -2461,6 +2683,104 @@ class NoaaMetarRemarksTest {
         assertEquals(1, remarks.weatherEvents().size());
         assertEquals(1, remarks.thunderstormLocations().size());
         assertFalse(remarks.isEmpty());
+    }
+
+    // ========== SECONDARY ALTIMETER TESTS ==========
+
+    @Test
+    @DisplayName("Should not be empty when only secondaryAltimeter is present")
+    void testIsEmptyWithOnlySecondaryAltimeter() {
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .secondaryAltimeter(Pressure.ofInchesHg(29.77))
+                .build();
+
+        assertFalse(remarks.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should build remarks with secondaryAltimeter via builder")
+    void testBuilder_SecondaryAltimeter() {
+        Pressure secondaryAltimeter = Pressure.ofInchesHg(29.77);
+
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .secondaryAltimeter(secondaryAltimeter)
+                .build();
+
+        assertThat(remarks.secondaryAltimeter()).isEqualTo(secondaryAltimeter);
+        assertThat(remarks.isEmpty()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should handle null secondaryAltimeter via builder")
+    void testBuilder_NullSecondaryAltimeter() {
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .secondaryAltimeter(null)
+                .build();
+
+        assertThat(remarks.secondaryAltimeter()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should build remarks with multiple fields including secondaryAltimeter")
+    void testBuilder_MultipleFieldsIncludingSecondaryAltimeter() {
+        AutomatedStationType stationType = AutomatedStationType.AO2;
+        Pressure slp = Pressure.hectopascals(1013.2);
+        Pressure secondaryAltimeter = Pressure.ofInchesHg(29.58);
+
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .automatedStationType(stationType)
+                .seaLevelPressure(slp)
+                .secondaryAltimeter(secondaryAltimeter)
+                .build();
+
+        assertThat(remarks.automatedStationType()).isEqualTo(stationType);
+        assertThat(remarks.seaLevelPressure()).isEqualTo(slp);
+        assertThat(remarks.secondaryAltimeter()).isEqualTo(secondaryAltimeter);
+        assertThat(remarks.isEmpty()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should include secondaryAltimeter in toString()")
+    void testToString_SecondaryAltimeter() {
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .secondaryAltimeter(Pressure.ofInchesHg(29.77))
+                .build();
+
+        String str = remarks.toString();
+        assertThat(str).contains("secondaryAltimeter");
+    }
+
+    @Test
+    @DisplayName("Should be equal when secondaryAltimeter is the same")
+    void testEqualityWithSecondaryAltimeter() {
+        Pressure secondaryAltimeter = Pressure.ofInchesHg(29.77);
+
+        NoaaMetarRemarks remarks1 = NoaaMetarRemarks.builder()
+                .automatedStationType(AutomatedStationType.AO2)
+                .secondaryAltimeter(secondaryAltimeter)
+                .build();
+
+        NoaaMetarRemarks remarks2 = NoaaMetarRemarks.builder()
+                .automatedStationType(AutomatedStationType.AO2)
+                .secondaryAltimeter(secondaryAltimeter)
+                .build();
+
+        assertEquals(remarks1, remarks2);
+        assertEquals(remarks1.hashCode(), remarks2.hashCode());
+    }
+
+    @Test
+    @DisplayName("Should not be equal when secondaryAltimeter differs")
+    void testInequalityWithDifferentSecondaryAltimeter() {
+        NoaaMetarRemarks remarks1 = NoaaMetarRemarks.builder()
+                .secondaryAltimeter(Pressure.ofInchesHg(29.77))
+                .build();
+
+        NoaaMetarRemarks remarks2 = NoaaMetarRemarks.builder()
+                .secondaryAltimeter(Pressure.ofInchesHg(29.58))
+                .build();
+
+        assertNotEquals(remarks1, remarks2);
     }
 
     // ========== 6-HOUR MAX/MIN TEMPERATURE TESTS ==========
@@ -3483,7 +3803,7 @@ class NoaaMetarRemarksTest {
     }
 
 
-// BONUS: Additional edge case tests
+    // BONUS: Additional edge case tests
 
     @Test
     @DisplayName("toString should handle single obscurationLayer correctly")
@@ -3912,6 +4232,10 @@ class NoaaMetarRemarksTest {
         Temperature dewpoint = Temperature.of(11.7);
         PeakWind peakWind = new PeakWind(280, 32, 15, 30);
         WindShift windShift = new WindShift(15, 30, true);
+        List<WindAtLocation> windsAtLocation = List.of(
+                WindAtLocation.atAltitude(1400, Wind.of(230, 10, "KT")),
+                WindAtLocation.atRunway("26", Wind.calm())
+        );
         Visibility min = Visibility.statuteMiles(0.5);
         Visibility max = Visibility.statuteMiles(2.0);
         VariableVisibility varVis = new VariableVisibility(min, max, null, null);
@@ -3938,6 +4262,7 @@ class NoaaMetarRemarksTest {
         ThunderstormLocation location2 = ThunderstormLocation.withMovement("CB", "W", "E");
         List<ThunderstormLocation> thunderstormLocations = List.of(location1, location2);
         PressureTendency tendency = PressureTendency.of(2, 3.2);
+        Pressure secondaryAltimeter = Pressure.ofInchesHg(30.02);
         Temperature sixHourMaxTemp = Temperature.of(14.2);
         Temperature sixHourMinTemp = Temperature.of(-0.1);
         Temperature twentyFourHourMaxTemp = Temperature.of(4.6);
@@ -3951,13 +4276,13 @@ class NoaaMetarRemarksTest {
         String freeText = "Additional remarks";
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
-                stationType, slp, temp, dewpoint, peakWind, windShift, varVis, variableCeiling, ceilingSecondSite,
+                stationType, slp, temp, dewpoint, peakWind, windShift, windsAtLocation, varVis, variableCeiling, ceilingSecondSite,
                 obscurationLayers, cloudTypes, towerVis, surfaceVis, hourly, sixHour, twentyFourHour, hailSize, weatherEvents,
-                thunderstormLocations, tendency, sixHourMaxTemp, sixHourMinTemp, twentyFourHourMaxTemp,
+                thunderstormLocations, tendency, secondaryAltimeter, sixHourMaxTemp, sixHourMinTemp, twentyFourHourMaxTemp,
                 twentyFourHourMinTemp, densityAltitudeFeet, automatedMaintenanceIndicators, maintenanceRequired, freeText
         );
 
-        // Verify first 13 fields
+        // Verify first 14 fields
         assertAll("First half of fields should be correctly set",
                 () -> assertEquals(stationType, remarks.automatedStationType()),
                 () -> assertEquals(slp, remarks.seaLevelPressure()),
@@ -3965,6 +4290,7 @@ class NoaaMetarRemarksTest {
                 () -> assertEquals(dewpoint, remarks.preciseDewpoint()),
                 () -> assertEquals(peakWind, remarks.peakWind()),
                 () -> assertEquals(windShift, remarks.windShift()),
+                () -> assertEquals(windsAtLocation, remarks.windsAtLocation()),
                 () -> assertEquals(varVis, remarks.variableVisibility()),
                 () -> assertEquals(variableCeiling, remarks.variableCeiling()),
                 () -> assertEquals(ceilingSecondSite, remarks.ceilingSecondSite()),
@@ -3984,6 +4310,10 @@ class NoaaMetarRemarksTest {
         Temperature dewpoint = Temperature.of(11.7);
         PeakWind peakWind = new PeakWind(280, 32, 15, 30);
         WindShift windShift = new WindShift(15, 30, true);
+        List<WindAtLocation> windsAtLocation = List.of(
+                WindAtLocation.atAltitude(1400, Wind.of(230, 10, "KT")),
+                WindAtLocation.atRunway("26", Wind.calm())
+        );
         Visibility min = Visibility.statuteMiles(0.5);
         Visibility max = Visibility.statuteMiles(2.0);
         VariableVisibility varVis = new VariableVisibility(min, max, null, null);
@@ -4010,6 +4340,7 @@ class NoaaMetarRemarksTest {
         ThunderstormLocation location2 = ThunderstormLocation.withMovement("CB", "W", "E");
         List<ThunderstormLocation> thunderstormLocations = List.of(location1, location2);
         PressureTendency tendency = PressureTendency.of(2, 3.2);
+        Pressure secondaryAltimeter = Pressure.ofInchesHg(30.02);
         Temperature sixHourMaxTemp = Temperature.of(14.2);
         Temperature sixHourMinTemp = Temperature.of(-0.1);
         Temperature twentyFourHourMaxTemp = Temperature.of(4.6);
@@ -4023,13 +4354,13 @@ class NoaaMetarRemarksTest {
         String freeText = "Additional remarks";
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
-                stationType, slp, temp, dewpoint, peakWind, windShift, varVis, variableCeiling, ceilingSecondSite,
+                stationType, slp, temp, dewpoint, peakWind, windShift, windsAtLocation, varVis, variableCeiling, ceilingSecondSite,
                 obscurationLayers, cloudTypes, towerVis, surfaceVis, hourly, sixHour, twentyFourHour, hailSize, weatherEvents,
-                thunderstormLocations, tendency, sixHourMaxTemp, sixHourMinTemp, twentyFourHourMaxTemp,
+                thunderstormLocations, tendency, secondaryAltimeter, sixHourMaxTemp, sixHourMinTemp, twentyFourHourMaxTemp,
                 twentyFourHourMinTemp, densityAltitudeFeet, automatedMaintenanceIndicators, maintenanceRequired, freeText
         );
 
-        // Verify remaining 15 fields
+        // Verify remaining 16 fields
         assertAll("Second half of fields should be correctly set",
                 () -> assertEquals(hourly, remarks.hourlyPrecipitation()),
                 () -> assertEquals(sixHour, remarks.sixHourPrecipitation()),
@@ -4038,6 +4369,7 @@ class NoaaMetarRemarksTest {
                 () -> assertEquals(weatherEvents, remarks.weatherEvents()),
                 () -> assertEquals(thunderstormLocations, remarks.thunderstormLocations()),
                 () -> assertEquals(tendency, remarks.pressureTendency()),
+                () -> assertEquals(secondaryAltimeter, remarks.secondaryAltimeter()),
                 () -> assertEquals(sixHourMaxTemp, remarks.sixHourMaxTemperature()),
                 () -> assertEquals(sixHourMinTemp, remarks.sixHourMinTemperature()),
                 () -> assertEquals(twentyFourHourMaxTemp, remarks.twentyFourHourMaxTemperature()),

--- a/noakweather-platform/weather-common/src/test/java/weather/model/components/remark/WindAtLocationTest.java
+++ b/noakweather-platform/weather-common/src/test/java/weather/model/components/remark/WindAtLocationTest.java
@@ -1,0 +1,198 @@
+/*
+ * NoakWeather Engineering Pipeline(TM) is a multi-source weather data engineering platform
+ * Copyright (C) 2025 bclasky1539
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package weather.model.components.remark;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import weather.model.components.Wind;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for WindAtLocation.
+ *
+ * @author bclasky1539
+ *
+ */
+class WindAtLocationTest {
+
+    @Test
+    @DisplayName("Should create wind at altitude via canonical constructor")
+    void testConstructor_AtAltitude() {
+        Wind wind = Wind.of(230, 10, "KT");
+        WindAtLocation windAtLocation = new WindAtLocation(1400, null, wind);
+
+        assertThat(windAtLocation.heightFeet()).isEqualTo(1400);
+        assertThat(windAtLocation.runway()).isNull();
+        assertThat(windAtLocation.wind()).isEqualTo(wind);
+    }
+
+    @Test
+    @DisplayName("Should create wind at runway via canonical constructor")
+    void testConstructor_AtRunway() {
+        Wind wind = Wind.of(0, 0, "KT");
+        WindAtLocation windAtLocation = new WindAtLocation(null, "26", wind);
+
+        assertThat(windAtLocation.heightFeet()).isNull();
+        assertThat(windAtLocation.runway()).isEqualTo("26");
+        assertThat(windAtLocation.wind()).isEqualTo(wind);
+    }
+
+    @Test
+    @DisplayName("Should throw when neither heightFeet nor runway is provided")
+    void testConstructor_NeitherHeightNorRunway_Throws() {
+        Wind wind = Wind.of(230, 10, "KT");
+
+        assertThatThrownBy(() -> new WindAtLocation(null, null, wind))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Either heightFeet or runway must be provided");
+    }
+
+    @Test
+    @DisplayName("Should throw when runway is blank")
+    void testConstructor_BlankRunway_Throws() {
+        Wind wind = Wind.of(230, 10, "KT");
+
+        assertThatThrownBy(() -> new WindAtLocation(null, "   ", wind))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Either heightFeet or runway must be provided");
+    }
+
+    @Test
+    @DisplayName("Should throw when both heightFeet and runway are provided")
+    void testConstructor_BothHeightAndRunway_Throws() {
+        Wind wind = Wind.of(230, 10, "KT");
+
+        assertThatThrownBy(() -> new WindAtLocation(1400, "26", wind))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cannot specify both heightFeet and runway");
+    }
+
+    @Test
+    @DisplayName("Should throw when wind is null")
+    void testConstructor_NullWind_Throws() {
+        assertThatThrownBy(() -> new WindAtLocation(1400, null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Wind cannot be null");
+    }
+
+    @Test
+    @DisplayName("isAtAltitude should return true for altitude-based reading")
+    void testIsAtAltitude_True() {
+        WindAtLocation windAtLocation = WindAtLocation.atAltitude(1400, Wind.of(230, 10, "KT"));
+
+        assertThat(windAtLocation.isAtAltitude()).isTrue();
+        assertThat(windAtLocation.isAtRunway()).isFalse();
+    }
+
+    @Test
+    @DisplayName("isAtRunway should return true for runway-based reading")
+    void testIsAtRunway_True() {
+        WindAtLocation windAtLocation = WindAtLocation.atRunway("26", Wind.of(0, 0, "KT"));
+
+        assertThat(windAtLocation.isAtRunway()).isTrue();
+        assertThat(windAtLocation.isAtAltitude()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should generate correct summary for altitude reading")
+    void testGetSummary_AtAltitude() {
+        WindAtLocation windAtLocation = WindAtLocation.atAltitude(1400, Wind.of(230, 10, "KT"));
+
+        assertThat(windAtLocation.getSummary())
+                .isEqualTo("Wind at 1400ft: 230° at 10 KT");
+    }
+
+    @Test
+    @DisplayName("Should generate correct summary for runway reading")
+    void testGetSummary_AtRunway() {
+        WindAtLocation windAtLocation = WindAtLocation.atRunway("26", Wind.of(0, 0, "KT"));
+
+        assertThat(windAtLocation.getSummary())
+                .isEqualTo("Wind at RWY 26: 0° at 0 KT");
+    }
+
+    @Test
+    @DisplayName("Should generate correct summary for variable direction wind")
+    void testGetSummary_VariableDirection() {
+        WindAtLocation windAtLocation = WindAtLocation.atRunway("32", Wind.variable(1, "KT"));
+
+        assertThat(windAtLocation.getSummary())
+                .contains("Wind at RWY 32:")
+                .contains("VRB");
+    }
+
+    @Test
+    @DisplayName("Factory atAltitude should create altitude-based reading")
+    void testFactory_AtAltitude() {
+        Wind wind = Wind.of(230, 10, "KT");
+        WindAtLocation windAtLocation = WindAtLocation.atAltitude(1400, wind);
+
+        assertThat(windAtLocation.heightFeet()).isEqualTo(1400);
+        assertThat(windAtLocation.runway()).isNull();
+        assertThat(windAtLocation.wind()).isEqualTo(wind);
+    }
+
+    @Test
+    @DisplayName("Factory atRunway should create runway-based reading")
+    void testFactory_AtRunway() {
+        Wind wind = Wind.of(0, 0, "KT");
+        WindAtLocation windAtLocation = WindAtLocation.atRunway("26", wind);
+
+        assertThat(windAtLocation.heightFeet()).isNull();
+        assertThat(windAtLocation.runway()).isEqualTo("26");
+        assertThat(windAtLocation.wind()).isEqualTo(wind);
+    }
+
+    @Test
+    @DisplayName("Should be equal when heightFeet, runway, and wind match")
+    void testEquality() {
+        WindAtLocation windAtLocation1 = WindAtLocation.atAltitude(1400, Wind.of(230, 10, "KT"));
+        WindAtLocation windAtLocation2 = WindAtLocation.atAltitude(1400, Wind.of(230, 10, "KT"));
+
+        assertThat(windAtLocation1).isEqualTo(windAtLocation2);
+        assertThat(windAtLocation1.hashCode()).isEqualTo(windAtLocation2.hashCode());
+    }
+
+    @Test
+    @DisplayName("Should not be equal when heightFeet differs")
+    void testInequality_DifferentHeight() {
+        WindAtLocation windAtLocation1 = WindAtLocation.atAltitude(1400, Wind.of(230, 10, "KT"));
+        WindAtLocation windAtLocation2 = WindAtLocation.atAltitude(1126, Wind.of(230, 10, "KT"));
+
+        assertThat(windAtLocation1).isNotEqualTo(windAtLocation2);
+    }
+
+    @Test
+    @DisplayName("Should not be equal when runway differs")
+    void testInequality_DifferentRunway() {
+        WindAtLocation windAtLocation1 = WindAtLocation.atRunway("26", Wind.of(0, 0, "KT"));
+        WindAtLocation windAtLocation2 = WindAtLocation.atRunway("32", Wind.of(0, 0, "KT"));
+
+        assertThat(windAtLocation1).isNotEqualTo(windAtLocation2);
+    }
+
+    @Test
+    @DisplayName("Should not be equal when wind differs")
+    void testInequality_DifferentWind() {
+        WindAtLocation windAtLocation1 = WindAtLocation.atAltitude(1400, Wind.of(230, 10, "KT"));
+        WindAtLocation windAtLocation2 = WindAtLocation.atAltitude(1400, Wind.of(180, 5, "KT"));
+
+        assertThat(windAtLocation1).isNotEqualTo(windAtLocation2);
+    }
+}

--- a/noakweather-platform/weather-common/src/test/java/weather/model/components/remark/WindAtLocationTest.java
+++ b/noakweather-platform/weather-common/src/test/java/weather/model/components/remark/WindAtLocationTest.java
@@ -165,8 +165,9 @@ class WindAtLocationTest {
         WindAtLocation windAtLocation1 = WindAtLocation.atAltitude(1400, Wind.of(230, 10, "KT"));
         WindAtLocation windAtLocation2 = WindAtLocation.atAltitude(1400, Wind.of(230, 10, "KT"));
 
-        assertThat(windAtLocation1).isEqualTo(windAtLocation2);
-        assertThat(windAtLocation1.hashCode()).isEqualTo(windAtLocation2.hashCode());
+        assertThat(windAtLocation1)
+                .isEqualTo(windAtLocation2)
+                .hasSameHashCodeAs(windAtLocation2);
     }
 
     @Test

--- a/noakweather-platform/weather-infrastructure/pom.xml
+++ b/noakweather-platform/weather-infrastructure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.19.1-SNAPSHOT</version>
+        <version>1.19.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-infrastructure</artifactId>

--- a/noakweather-platform/weather-ingestion/pom.xml
+++ b/noakweather-platform/weather-ingestion/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.19.1-SNAPSHOT</version>
+        <version>1.19.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-ingestion</artifactId>

--- a/noakweather-platform/weather-processing/pom.xml
+++ b/noakweather-platform/weather-processing/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.19.1-SNAPSHOT</version>
+        <version>1.19.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-processing</artifactId>

--- a/noakweather-platform/weather-processing/src/main/java/weather/processing/parser/noaa/NoaaAviationWeatherParser.java
+++ b/noakweather-platform/weather-processing/src/main/java/weather/processing/parser/noaa/NoaaAviationWeatherParser.java
@@ -19,6 +19,7 @@ package weather.processing.parser.noaa;
 import weather.model.NoaaWeatherData;
 import weather.model.WeatherConditions;
 import weather.model.components.*;
+import weather.model.enums.PressureUnit;
 import weather.model.enums.SkyCoverage;
 import weather.processing.parser.common.WeatherParser;
 
@@ -31,26 +32,25 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Abstract base class for NOAA aviation weather parsers (METAR and TAF).
- *
+ * <p>
  * Consolidates shared parsing logic for common aviation weather elements:
  * - Wind
  * - Visibility
  * - Present weather phenomena
  * - Sky conditions (clouds)
  * - Runway visual range
- *
+ * <p>
  * Design Philosophy:
  * - Single source of truth for aviation weather parsing
  * - Eliminates code duplication between METAR and TAF parsers
  * - Shared handlers implemented once, maintained once
  * - Subclasses handle report-specific logic (remarks, forecast periods, etc.)
- *
+ * <p>
  * Generic Type Parameter:
  * - T extends NoaaWeatherData: Allows type-safe access to specific data types
- *   (NoaaMetarData or NoaaTafData) without casting
+ * (NoaaMetarData or NoaaTafData) without casting
  *
  * @param <T> The specific weather data type (NoaaMetarData or NoaaTafData)
- *
  * @author bclasky1539
  *
  */
@@ -88,15 +88,17 @@ public abstract class NoaaAviationWeatherParser<T extends NoaaWeatherData>
      */
     protected T weatherData;
 
+    protected static final String GROUP_PRESSURE_CHANGE = "press";
+
     // ==================== INITIALIZATION ====================
 
     /**
      * Initialize or reset shared parsing state for building weather conditions.
-     *
+     * <p>
      * Called by subclasses in two scenarios:
      * 1. During parse initialization (METAR and TAF)
      * 2. When starting a new forecast period (TAF only)
-     *
+     * <p>
      * This method resets the conditions builder and clears accumulated lists,
      * preparing to parse a new set of weather conditions.
      */
@@ -110,7 +112,7 @@ public abstract class NoaaAviationWeatherParser<T extends NoaaWeatherData>
 
     /**
      * Handle wind: "19005KT" or "19005G15KT" or "VRB02KT"
-     *
+     * <p>
      * Creates Wind object and adds to conditions builder.
      * Handles:
      * - Direction (degrees, VRB for variable, or null for calm)
@@ -195,10 +197,10 @@ public abstract class NoaaAviationWeatherParser<T extends NoaaWeatherData>
      * Create appropriate Wind object based on parsed values.
      *
      * @param directionStr original direction string for VRB check
-     * @param direction parsed direction value
-     * @param speed wind speed
-     * @param gust gust speed (optional)
-     * @param unit wind unit
+     * @param direction    parsed direction value
+     * @param speed        wind speed
+     * @param gust         gust speed (optional)
+     * @param unit         wind unit
      * @return Wind object, or null if invalid
      */
     private Wind createWind(String directionStr, Integer direction, Integer speed,
@@ -236,9 +238,9 @@ public abstract class NoaaAviationWeatherParser<T extends NoaaWeatherData>
      * Log wind data for debugging.
      *
      * @param direction wind direction
-     * @param speed wind speed
-     * @param gust gust speed
-     * @param unit wind unit
+     * @param speed     wind speed
+     * @param gust      gust speed
+     * @param unit      wind unit
      */
     private void logWindData(Integer direction, Integer speed, Integer gust, String unit) {
         if (direction != null && speed != null) {
@@ -251,7 +253,7 @@ public abstract class NoaaAviationWeatherParser<T extends NoaaWeatherData>
 
     /**
      * Handle visibility: "10SM", "9999", "1/2SM", "CAVOK", etc.
-     *
+     * <p>
      * Creates Visibility object and adds to conditions builder.
      * Handles:
      * - Special conditions (CAVOK, NDV)
@@ -374,7 +376,7 @@ public abstract class NoaaAviationWeatherParser<T extends NoaaWeatherData>
      * Log visibility parsing error with consistent message format.
      *
      * @param distanceStr The distance string that failed to parse
-     * @param e The NumberFormatException that occurred
+     * @param e           The NumberFormatException that occurred
      */
     private void logVisibilityParseError(String distanceStr, NumberFormatException e) {
         LOGGER.warn("Failed to parse visibility distance: '{}' - {}", distanceStr, e.getMessage());
@@ -420,7 +422,7 @@ public abstract class NoaaAviationWeatherParser<T extends NoaaWeatherData>
     /**
      * Handle present weather phenomena.
      * Parses weather codes like: -RA, +TSRA, VCFG, BR, NSW
-     *
+     * <p>
      * Creates PresentWeather object and adds to list.
      * Multiple weather phenomena can be present in a single report.
      *
@@ -433,11 +435,18 @@ public abstract class NoaaAviationWeatherParser<T extends NoaaWeatherData>
 
         String weatherString = matcher.group(0).trim();
 
+        // ICAO missing-data placeholder: the entire token is slashes (e.g. "//////"),
+        // not a real weather phenomenon with an unknown subcomponent. Skip it rather
+        // than creating a bogus PresentWeather entry from the placeholder text itself.
+        if (!weatherString.isEmpty() && weatherString.chars().allMatch(c -> c == '/')) {
+            LOGGER.debug("Skipping missing-data placeholder in present weather: '{}'", weatherString);
+            return;
+        }
+
         try {
             PresentWeather presentWeather = PresentWeather.parse(weatherString);
             presentWeatherList.add(presentWeather);
 
-            // Determine primary phenomenon for logging
             String phenomenon = getPrimaryPhenomenon(presentWeather);
 
             LOGGER.debug("Present Weather: {} (Intensity: {}, Descriptor: {}, Phenomena: {})",
@@ -466,12 +475,12 @@ public abstract class NoaaAviationWeatherParser<T extends NoaaWeatherData>
     /**
      * Handle sky condition (cloud layers).
      * Parses sky condition codes like: FEW250, SCT100, BKN050CB, OVC020, SKC, VV008
-     *
+     * <p>
      * Format: [COVERAGE][HEIGHT][TYPE]
      * - Coverage: SKC, CLR, FEW, SCT, BKN, OVC, VV, etc.
      * - Height: 3-4 digits (in hundreds of feet)
      * - Type: CB (cumulonimbus), TCU (towering cumulus), etc.
-     *
+     * <p>
      * Creates SkyCondition object and adds to list.
      * Multiple cloud layers can be present.
      *
@@ -554,7 +563,7 @@ public abstract class NoaaAviationWeatherParser<T extends NoaaWeatherData>
      * Heights are encoded as hundreds of feet (e.g., "050" = 5000 feet).
      *
      * @param heightStr the height string from METAR/TAF (could be null)
-     * @param coverage the sky coverage (used for validation)
+     * @param coverage  the sky coverage (used for validation)
      * @return height in feet, or null if not applicable
      */
     protected Integer parseHeight(String heightStr, SkyCoverage coverage) {
@@ -604,9 +613,161 @@ public abstract class NoaaAviationWeatherParser<T extends NoaaWeatherData>
     }
 
     /**
+     * Handle altimeter/pressure setting.
+     * <p>
+     * Formats:
+     * - A3015 → 30.15 inHg (North America)
+     * - Q1013 → 1013 hPa (International)
+     * - QNH1013 → 1013 hPa
+     * - 2992INS → 29.92 inHg (older format)
+     * - //// → Missing
+     */
+    protected void handleAltimeter(Matcher matcher) {
+        if (weatherData == null) {
+            return;
+        }
+
+        String unit1 = matcher.group("unit");
+        String pressureStr = matcher.group(GROUP_PRESSURE_CHANGE);
+        String unit2 = matcher.group("unit2");
+
+        // Handle missing pressure
+        if ("////".equals(pressureStr)) {
+            LOGGER.debug("Altimeter: Missing (////)");
+            return;
+        }
+
+        try {
+            // Determine unit and parse pressure
+            Pressure pressure = parsePressure(unit1, pressureStr, unit2);
+
+            if (pressure != null) {
+                conditionsBuilder.pressure(pressure);
+
+                LOGGER.debug("Altimeter: {}", pressure.getSummary());
+            }
+
+        } catch (IllegalArgumentException e) {
+            LOGGER.warn("Failed to parse altimeter '{}': {}",
+                    matcher.group(0).trim(), e.getMessage());
+        }
+    }
+
+    /**
+     * Parse pressure value and determine unit.
+     * <p>
+     * Logic:
+     * - "A" or "AA" prefix → inches of mercury (divide by 100)
+     * - "Q" or "QNH" prefix → hectopascals
+     * - "INS" suffix → inches of mercury (divide by 100)
+     * - 4 digits starting with 2 or 3 → inches of mercury (divide by 100)
+     * - 4 digits starting with 0 or 1 → hectopascals
+     * - 3 digits → hectopascals
+     *
+     * @param unit1       Prefix unit indicator
+     * @param pressureStr Pressure digits
+     * @param unit2       Suffix unit indicator
+     * @return Pressure object, or null if invalid
+     */
+    protected Pressure parsePressure(String unit1, String pressureStr, String unit2) {
+        if (pressureStr == null || pressureStr.isBlank()) {
+            return null;
+        }
+
+        // Handle OCR error: O → 0
+        String normalized = pressureStr.replace('O', '0');
+
+        try {
+            int pressureValue = Integer.parseInt(normalized);
+
+            // Determine unit based on prefix
+            if (unit1 != null && !unit1.isBlank()) {
+                return parsePressureWithPrefix(unit1, pressureValue);
+            }
+
+            // Determine unit based on suffix
+            if ("INS".equals(unit2)) {
+                return parseInchesHg(pressureValue);
+            }
+
+            // Determine unit based on value
+            return parsePressureByValue(pressureValue);
+
+        } catch (NumberFormatException e) {
+            LOGGER.warn("Invalid pressure format: {}", pressureStr);
+            return null;
+        }
+    }
+
+    /**
+     * Parse pressure with unit prefix (A, AA, Q, QNH).
+     *
+     * @param prefix Unit prefix
+     * @param value  Pressure value
+     * @return Pressure object
+     */
+    private Pressure parsePressureWithPrefix(String prefix, int value) {
+        return switch (prefix.toUpperCase()) {
+            case "A", "AA" -> parseInchesHg(value);
+            case "Q", "QNH" -> parseHectopascals(value);
+            default -> {
+                LOGGER.warn("Unknown pressure unit prefix: {}", prefix);
+                yield parsePressureByValue(value);
+            }
+        };
+    }
+
+    /**
+     * Parse pressure as inches of mercury.
+     * Value is divided by 100 (e.g., 3015 → 30.15 inHg).
+     *
+     * @param value Pressure value (e.g., 3015)
+     * @return Pressure in inches of mercury
+     */
+    private Pressure parseInchesHg(int value) {
+        double inHg = value / 100.0;
+        return new Pressure(inHg, PressureUnit.INCHES_HG);
+    }
+
+    /**
+     * Parse pressure as hectopascals.
+     *
+     * @param value Pressure value (e.g., 1013)
+     * @return Pressure in hectopascals
+     */
+    private Pressure parseHectopascals(int value) {
+        return new Pressure((double) value, PressureUnit.HECTOPASCALS);
+    }
+
+    /**
+     * Determine pressure unit based on value heuristics.
+     * <p>
+     * - 4 digits starting with 2 or 3 → inches Hg (e.g., 2992, 3015)
+     * - 4 digits starting with 0 or 1 → hPa (e.g., 1013, 0998)
+     * - 3 digits → hPa (e.g., 998)
+     *
+     * @param value Pressure value
+     * @return Pressure object
+     */
+    private Pressure parsePressureByValue(int value) {
+        // 4-digit values
+        if (value >= 1000) {
+            // 2xxx or 3xxx → inches of mercury
+            if (value >= 2000 && value < 4000) {
+                return parseInchesHg(value);
+            }
+            // 0xxx or 1xxx → hectopascals
+            return parseHectopascals(value);
+        }
+
+        // 3-digit values → assume hectopascals
+        return parseHectopascals(value);
+    }
+
+    /**
      * Handle runway visual range (RVR).
      * Note: RVR is common in METAR but rare in TAF.
-     *
+     * <p>
      * Subclasses can override for specific RVR handling.
      *
      * @param matcher Regex matcher positioned at RVR group
@@ -643,7 +804,7 @@ public abstract class NoaaAviationWeatherParser<T extends NoaaWeatherData>
      * Log unparsed tokens for debugging.
      *
      * @param mainBody remaining main body tokens
-     * @param remarks remaining remark tokens
+     * @param remarks  remaining remark tokens
      */
     protected void logUnparsedTokens(String mainBody, String remarks) {
         if (LOGGER.isDebugEnabled() && mainBody != null && !mainBody.trim().isEmpty()) {

--- a/noakweather-platform/weather-processing/src/main/java/weather/processing/parser/noaa/NoaaMetarParser.java
+++ b/noakweather-platform/weather-processing/src/main/java/weather/processing/parser/noaa/NoaaMetarParser.java
@@ -21,7 +21,6 @@ import weather.model.NoaaWeatherData;
 import weather.model.components.*;
 import weather.model.components.remark.*;
 import weather.model.enums.AutomatedStationType;
-import weather.model.enums.PressureUnit;
 import weather.processing.parser.common.ParseResult;
 import weather.utils.IndexedLinkedHashMap;
 
@@ -68,7 +67,6 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
 
     // Pressure Tendency Pattern Groups
     private static final String GROUP_TENDENCY_CODE = "tend";
-    private static final String GROUP_PRESSURE_CHANGE = "press";
     private static final String GROUP_HEIGHT_CODE = "height";
 
     // Pattern registry for METAR parsing
@@ -797,157 +795,6 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
         }
     }
 
-    /**
-     * Handle altimeter/pressure setting.
-     * <p>
-     * Formats:
-     * - A3015 → 30.15 inHg (North America)
-     * - Q1013 → 1013 hPa (International)
-     * - QNH1013 → 1013 hPa
-     * - 2992INS → 29.92 inHg (older format)
-     * - //// → Missing
-     */
-    private void handleAltimeter(Matcher matcher) {
-        if (weatherData == null) {
-            return;
-        }
-
-        String unit1 = matcher.group("unit");
-        String pressureStr = matcher.group(GROUP_PRESSURE_CHANGE);
-        String unit2 = matcher.group("unit2");
-
-        // Handle missing pressure
-        if ("////".equals(pressureStr)) {
-            LOGGER.debug("Altimeter: Missing (////)");
-            return;
-        }
-
-        try {
-            // Determine unit and parse pressure
-            Pressure pressure = parsePressure(unit1, pressureStr, unit2);
-
-            if (pressure != null) {
-                conditionsBuilder.pressure(pressure);
-
-                LOGGER.debug("Altimeter: {}", pressure.getSummary());
-            }
-
-        } catch (IllegalArgumentException e) {
-            LOGGER.warn("Failed to parse altimeter '{}': {}",
-                    matcher.group(0).trim(), e.getMessage());
-        }
-    }
-
-    /**
-     * Parse pressure value and determine unit.
-     * <p>
-     * Logic:
-     * - "A" or "AA" prefix → inches of mercury (divide by 100)
-     * - "Q" or "QNH" prefix → hectopascals
-     * - "INS" suffix → inches of mercury (divide by 100)
-     * - 4 digits starting with 2 or 3 → inches of mercury (divide by 100)
-     * - 4 digits starting with 0 or 1 → hectopascals
-     * - 3 digits → hectopascals
-     *
-     * @param unit1       Prefix unit indicator
-     * @param pressureStr Pressure digits
-     * @param unit2       Suffix unit indicator
-     * @return Pressure object, or null if invalid
-     */
-    private Pressure parsePressure(String unit1, String pressureStr, String unit2) {
-        if (pressureStr == null || pressureStr.isBlank()) {
-            return null;
-        }
-
-        // Handle OCR error: O → 0
-        String normalized = pressureStr.replace('O', '0');
-
-        try {
-            int pressureValue = Integer.parseInt(normalized);
-
-            // Determine unit based on prefix
-            if (unit1 != null && !unit1.isBlank()) {
-                return parsePressureWithPrefix(unit1, pressureValue);
-            }
-
-            // Determine unit based on suffix
-            if ("INS".equals(unit2)) {
-                return parseInchesHg(pressureValue);
-            }
-
-            // Determine unit based on value
-            return parsePressureByValue(pressureValue);
-
-        } catch (NumberFormatException e) {
-            LOGGER.warn("Invalid pressure format: {}", pressureStr);
-            return null;
-        }
-    }
-
-    /**
-     * Parse pressure with unit prefix (A, AA, Q, QNH).
-     *
-     * @param prefix Unit prefix
-     * @param value  Pressure value
-     * @return Pressure object
-     */
-    private Pressure parsePressureWithPrefix(String prefix, int value) {
-        return switch (prefix.toUpperCase()) {
-            case "A", "AA" -> parseInchesHg(value);
-            case "Q", "QNH" -> parseHectopascals(value);
-            default -> {
-                LOGGER.warn("Unknown pressure unit prefix: {}", prefix);
-                yield parsePressureByValue(value);
-            }
-        };
-    }
-
-    /**
-     * Parse pressure as inches of mercury.
-     * Value is divided by 100 (e.g., 3015 → 30.15 inHg).
-     *
-     * @param value Pressure value (e.g., 3015)
-     * @return Pressure in inches of mercury
-     */
-    private Pressure parseInchesHg(int value) {
-        double inHg = value / 100.0;
-        return new Pressure(inHg, PressureUnit.INCHES_HG);
-    }
-
-    /**
-     * Parse pressure as hectopascals.
-     *
-     * @param value Pressure value (e.g., 1013)
-     * @return Pressure in hectopascals
-     */
-    private Pressure parseHectopascals(int value) {
-        return new Pressure((double) value, PressureUnit.HECTOPASCALS);
-    }
-
-    /**
-     * Determine pressure unit based on value heuristics.
-     * <p>
-     * - 4 digits starting with 2 or 3 → inches Hg (e.g., 2992, 3015)
-     * - 4 digits starting with 0 or 1 → hPa (e.g., 1013, 0998)
-     * - 3 digits → hPa (e.g., 998)
-     *
-     * @param value Pressure value
-     * @return Pressure object
-     */
-    private Pressure parsePressureByValue(int value) {
-        // 4-digit values
-        if (value >= 1000) {
-            // 2xxx or 3xxx → inches of mercury
-            if (value >= 2000 && value < 4000) {
-                return parseInchesHg(value);
-            }
-            // 0xxx or 1xxx → hectopascals
-            return parseHectopascals(value);
-        }
-
-        // 3-digit values → assume hectopascals
-        return parseHectopascals(value);
-    }
 
     /**
      * Handle NOSIG (No Significant Change) indicator in main METAR body.
@@ -1039,6 +886,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
             remaining = handleHourlyTemperatureSequential(remaining, remarksBuilder);
             remaining = handlePeakWindSequential(remaining, remarksBuilder);
             remaining = handleWindShiftSequential(remaining, remarksBuilder);
+            remaining = handleWindAtLocationSequential(remaining, remarksBuilder);
             remaining = handleVariableVisibilitySequential(remaining, remarksBuilder);
             remaining = handleVariableCeilingSequential(remaining, remarksBuilder);
             remaining = handleCeilingSecondSiteSequential(remaining, remarksBuilder);
@@ -1055,6 +903,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
             remaining = handle24HourMaxMinTemperatureSequential(remaining, remarksBuilder);
             remaining = handleDensityAltitudeSequential(remaining, remarksBuilder);
             remaining = handleAutomatedMaintenanceSequential(remaining, remarksBuilder);
+            remaining = handleSecondaryAltimeterSequential(remaining, remarksBuilder);
 
             // Continue while we're making progress
         } while (!Objects.equals(remaining, previous));
@@ -1467,6 +1316,90 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
                     remarksText.substring(0, Math.min(20, remarksText.length())), e);
             return remarksText.substring(matcher.end()).trim();
         }
+    }
+
+    /**
+     * Handle wind-at-location remarks (altitude or runway-specific wind readings).
+     * Format: WIND ####FT ddd(dd)KT or WIND RWY ## ddd(dd)KT
+     * Multiple entries may be chained in sequence.
+     * <p>
+     * Examples:
+     * - WIND 1400FT 23010KT → wind at 1400ft altitude
+     * - WIND RWY 26 00000KT → wind at runway 26
+     *
+     * @param remarksText remaining remarks text to process
+     * @param remarks     the remarks builder to populate
+     * @return the remaining text after processing (never null)
+     */
+    private String handleWindAtLocationSequential(String remarksText, NoaaMetarRemarks.Builder remarks) {
+        if (remarksText == null || remarksText.trim().isEmpty()) {
+            return remarksText != null ? remarksText : "";
+        }
+
+        String remaining = remarksText.trim();
+        Matcher matcher = WIND_AT_LOCATION_PATTERN.matcher(remaining);
+
+        while (matcher.find() && matcher.start() == 0) {
+            int matchEnd = matcher.end();
+            remaining = processWindAtLocationMatch(matcher, matchEnd, remaining, remarks);
+            remaining = remaining.trim();
+            matcher = WIND_AT_LOCATION_PATTERN.matcher(remaining);
+        }
+
+        return remaining;
+    }
+
+    /**
+     * Process a single wind-at-location pattern match.
+     *
+     * @param matcher   the pattern matcher (must not be null)
+     * @param matchEnd  the end position of the match
+     * @param remaining the remaining text (must not be null)
+     * @param remarks   the remarks builder (must not be null)
+     * @return the remaining text after processing this match (never null)
+     */
+    private String processWindAtLocationMatch(Matcher matcher, int matchEnd, String remaining,
+                                              NoaaMetarRemarks.Builder remarks) {
+        try {
+            WindAtLocation windAtLocation = buildWindAtLocation(matcher);
+            remarks.addWindAtLocation(windAtLocation);
+
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Wind at location: {}", windAtLocation.getSummary());
+            }
+        } catch (IllegalArgumentException e) {
+            int endIndex = Math.min(matchEnd, remaining.length());
+            LOGGER.warn("Invalid wind-at-location in remarks: {}",
+                    remaining.substring(0, endIndex), e);
+        }
+
+        return remaining.substring(matchEnd).trim();
+    }
+
+    /**
+     * Extract wind-at-location components from a pattern matcher and construct
+     * the corresponding WindAtLocation value object.
+     *
+     * @param matcher the pattern matcher (must not be null)
+     * @return the constructed WindAtLocation (never null)
+     * @throws IllegalArgumentException if the matched data is invalid
+     */
+    private WindAtLocation buildWindAtLocation(Matcher matcher) {
+        String heightStr = matcher.group(GROUP_HEIGHT_CODE);
+        String runway = matcher.group("runway");
+        String dirStr = matcher.group("dir");
+        String speedStr = matcher.group("speed");
+        String gustStr = matcher.group("gust");
+        String unit = matcher.group("unit");
+
+        Integer height = heightStr != null ? Integer.parseInt(heightStr) : null;
+        Integer direction = "VRB".equals(dirStr) ? null : Integer.parseInt(dirStr);
+        int speed = Integer.parseInt(speedStr);
+        Integer gust = gustStr != null ? Integer.parseInt(gustStr) : null;
+
+        Wind wind = new Wind(direction, speed, gust, null, null, unit);
+
+        return new WindAtLocation(height, runway, wind);
     }
 
     /**
@@ -2325,6 +2258,65 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
 
         // Use PressureTendency.fromMetar factory method
         return PressureTendency.fromMetar(tendencyCode, pressureChangeStr);
+    }
+
+    /**
+     * Handle secondary altimeter setting repeated inside the remarks section.
+     * Common in Philippines/Taiwan-region METARs where the main body reports
+     * altimeter in ICAO hPa format (Q####) and remarks repeat it in US-style
+     * inches of mercury (A####) as a redundant confirmation.
+     * <p>
+     * Example: RMK A2977 → 29.77 inHg
+     *
+     * @param remarksText remaining remarks text to process
+     * @param remarks     the remarks builder to populate
+     * @return the remaining text after processing (never null)
+     */
+    private String handleSecondaryAltimeterSequential(String remarksText, NoaaMetarRemarks.Builder remarks) {
+        if (remarksText == null || remarksText.trim().isEmpty()) {
+            return remarksText != null ? remarksText : "";
+        }
+
+        String remaining = remarksText.trim();
+        Matcher matcher = ALTIMETER_PATTERN.matcher(remaining);
+
+        if (matcher.find() && matcher.start() == 0) {
+            processSecondaryAltimeterMatch(matcher, remarks);
+            remaining = remaining.substring(matcher.end()).trim();
+        }
+
+        return remaining;
+    }
+
+    /**
+     * Process a single secondary altimeter pattern match, storing the parsed
+     * pressure on the remarks builder if valid.
+     *
+     * @param matcher the pattern matcher (must not be null)
+     * @param remarks the remarks builder (must not be null)
+     */
+    private void processSecondaryAltimeterMatch(Matcher matcher, NoaaMetarRemarks.Builder remarks) {
+        String pressureStr = matcher.group(GROUP_PRESSURE_CHANGE);
+
+        if ("////".equals(pressureStr)) {
+            return;
+        }
+
+        String unit1 = matcher.group("unit");
+        String unit2 = matcher.group("unit2");
+
+        try {
+            Pressure pressure = parsePressure(unit1, pressureStr, unit2);
+            if (pressure != null) {
+                remarks.secondaryAltimeter(pressure);
+
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Secondary altimeter: {}", pressure.getSummary());
+                }
+            }
+        } catch (IllegalArgumentException e) {
+            LOGGER.warn("Failed to parse secondary altimeter in remarks: {}", matcher.group(0).trim(), e);
+        }
     }
 
     /**

--- a/noakweather-platform/weather-processing/src/main/java/weather/processing/parser/noaa/RegExprConst.java
+++ b/noakweather-platform/weather-processing/src/main/java/weather/processing/parser/noaa/RegExprConst.java
@@ -152,7 +152,7 @@ public final class RegExprConst {
      * Also: "QNH1013"
      */
     public static final Pattern ALTIMETER_PATTERN = Pattern.compile(
-            "^(?<unit>A{1,2}|Q|QNH)?(?<press>[\\dO]{3,4}|////)(?<unit2>INS)?\\s+"
+            "^(?<unit>A{1,2}|Q|QNH)?(?<press>[\\dO]{3,4}|////)(?<unit2>INS)?(?=\\s|$)"
     );
 
     /**
@@ -232,6 +232,20 @@ public final class RegExprConst {
     public static final Pattern WIND_SHIFT_PATTERN = Pattern.compile(
             "^WSHFT (?<hour>\\d{2})?(?<min>\\d{2})(\\s+(?<front>FROPA))?\\s*"
 
+    );
+
+    /**
+     * Wind at a specific location — altitude or runway (Norwegian/Arctic convention).
+     * Reports wind speed/direction at a specific altitude or runway, distinct
+     * from surface wind. Multiple entries can be chained in the same remarks
+     * string (e.g. one runway reading followed by one altitude reading).
+     * Example: "WIND 1400FT 23010KT", "WIND RWY 26 00000KT", "WIND RWY 32 VRB01KT"
+     * Complexity mirrors WIND_PATTERN to support the same direction/speed/gust/unit variations
+     */
+    @SuppressWarnings("java:S5843") // Complex regex required for wind format with all variations
+    public static final Pattern WIND_AT_LOCATION_PATTERN = Pattern.compile(
+            "^WIND\\s+(?:(?<height>\\d{3,5})FT|RWY\\s+(?<runway>\\d{1,2}[LRC]?))\\s+" +
+                    "(?<dir>\\d{3}|VRB)(?<speed>\\d{2,3})(G(?<gust>\\d{2,3}))?(?<unit>KTS?|MPS|KMH)(?=\\s|$)"
     );
 
     /**

--- a/noakweather-platform/weather-processing/src/test/java/weather/processing/parser/noaa/NoaaAviationWeatherParserTest.java
+++ b/noakweather-platform/weather-processing/src/test/java/weather/processing/parser/noaa/NoaaAviationWeatherParserTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import weather.model.NoaaWeatherData;
 import weather.model.WeatherConditions;
 import weather.model.components.*;
+import weather.model.enums.PressureUnit;
 import weather.model.enums.SkyCoverage;
 import weather.processing.parser.common.ParseResult;
 
@@ -38,10 +39,10 @@ import static weather.processing.parser.noaa.RegExprConst.*;
 
 /**
  * Tests for NoaaAviationWeatherParser base class functionality.
- *
+ * <p>
  * Since NoaaAviationWeatherParser is abstract, we test it through a concrete
  * test implementation that exposes the protected methods for testing.
- *
+ * <p>
  * Tests cover:
  * - Wind parsing
  * - Visibility parsing (all formats)
@@ -398,6 +399,38 @@ class NoaaAviationWeatherParserTest {
 
             assertThat(conditions.presentWeather()).hasSize(2);
         }
+
+        @Test
+        @DisplayName("handlePresentWeather should not create entry from missing-data slash placeholder - MKJP real-world (Issue #54)")
+        void testHandlePresentWeather_MissingDataSlashPlaceholder_MKJP() {
+            parser.initializeSharedState();
+            parser.weatherData = new TestWeatherData("TEST", Instant.now());
+
+            String input = "////// ";
+            Matcher matcher = PRESENT_WEATHER_PATTERN.matcher(input);
+            assertThat(matcher.find()).isTrue();
+            parser.handlePresentWeather(matcher);
+
+            WeatherConditions conditions = parser.buildConditions();
+
+            assertThat(conditions.presentWeather()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("handlePresentWeather should not create entry from 5-slash missing-data placeholder - MKJP real-world (Issue #54)")
+        void testHandlePresentWeather_FiveSlashPlaceholder_MKJP() {
+            parser.initializeSharedState();
+            parser.weatherData = new TestWeatherData("TEST", Instant.now());
+
+            String input = "///// ";
+            Matcher matcher = PRESENT_WEATHER_PATTERN.matcher(input);
+            assertThat(matcher.find()).isTrue();
+            parser.handlePresentWeather(matcher);
+
+            WeatherConditions conditions = parser.buildConditions();
+
+            assertThat(conditions.presentWeather()).isEmpty();
+        }
     }
 
     // ==================== SKY CONDITION TESTS ====================
@@ -497,6 +530,103 @@ class NoaaAviationWeatherParserTest {
 
             // Unknown coverage should be skipped
             assertThat(conditions.skyConditions()).isEmpty();
+        }
+    }
+
+    // ========== ALTIMETER/PRESSURE HANDLER TESTS (shared base-class logic) ==========
+    @Nested
+    @DisplayName("Altimeter/Pressure Parsing Tests")
+    class AltimeterPressureTests {
+
+        @Test
+        @DisplayName("handleAltimeter should parse North American A-prefix format")
+        void testHandleAltimeter_APrefix() {
+            parser.initializeSharedState();
+            parser.weatherData = new TestWeatherData("TEST", Instant.now());
+
+            String input = "A3015 ";
+            Matcher matcher = ALTIMETER_PATTERN.matcher(input);
+            assertThat(matcher.find()).isTrue();
+            parser.handleAltimeter(matcher);
+
+            Pressure pressure = parser.buildConditions().pressure();
+
+            assertThat(pressure).isNotNull();
+            assertThat(pressure.value()).isEqualTo(30.15, within(0.01));
+            assertThat(pressure.unit()).isEqualTo(PressureUnit.INCHES_HG);
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "'Q1013 ', 1013.0, 'International Q-prefix format'",
+                "'QNH1013 ', 1013.0, 'QNH format'",
+                "'998 ', 998.0, 'Value-based heuristic, no prefix/suffix'"
+        })
+        @DisplayName("handleAltimeter should parse hectopascal formats correctly")
+        void testHandleAltimeter_HectopascalFormats(String input, double expectedValue, String scenario) {
+            parser.initializeSharedState();
+            parser.weatherData = new TestWeatherData("TEST", Instant.now());
+
+            Matcher matcher = ALTIMETER_PATTERN.matcher(input);
+            assertThat(matcher.find()).as(scenario).isTrue();
+            parser.handleAltimeter(matcher);
+
+            Pressure pressure = parser.buildConditions().pressure();
+
+            assertThat(pressure).as(scenario).isNotNull();
+            assertThat(pressure.value()).as(scenario).isEqualTo(expectedValue, within(0.01));
+            assertThat(pressure.unit()).as(scenario).isEqualTo(PressureUnit.HECTOPASCALS);
+        }
+
+        @Test
+        @DisplayName("handleAltimeter should parse older INS-suffix format")
+        void testHandleAltimeter_INSSuffix() {
+            parser.initializeSharedState();
+            parser.weatherData = new TestWeatherData("TEST", Instant.now());
+
+            String input = "2992INS ";
+            Matcher matcher = ALTIMETER_PATTERN.matcher(input);
+            assertThat(matcher.find()).isTrue();
+            parser.handleAltimeter(matcher);
+
+            Pressure pressure = parser.buildConditions().pressure();
+
+            assertThat(pressure).isNotNull();
+            assertThat(pressure.value()).isEqualTo(29.92, within(0.01));
+            assertThat(pressure.unit()).isEqualTo(PressureUnit.INCHES_HG);
+        }
+
+        @Test
+        @DisplayName("handleAltimeter should not set pressure for missing data (////)")
+        void testHandleAltimeter_MissingData() {
+            parser.initializeSharedState();
+            parser.weatherData = new TestWeatherData("TEST", Instant.now());
+
+            String input = "//// ";
+            Matcher matcher = ALTIMETER_PATTERN.matcher(input);
+            assertThat(matcher.find()).isTrue();
+            parser.handleAltimeter(matcher);
+
+            Pressure pressure = parser.buildConditions().pressure();
+
+            assertThat(pressure).isNull();
+        }
+
+        @Test
+        @DisplayName("handleAltimeter should normalize OCR error (O instead of 0)")
+        void testHandleAltimeter_OcrErrorNormalization() {
+            parser.initializeSharedState();
+            parser.weatherData = new TestWeatherData("TEST", Instant.now());
+
+            String input = "A3O15 ";
+            Matcher matcher = ALTIMETER_PATTERN.matcher(input);
+            assertThat(matcher.find()).isTrue();
+            parser.handleAltimeter(matcher);
+
+            Pressure pressure = parser.buildConditions().pressure();
+
+            assertThat(pressure).isNotNull();
+            assertThat(pressure.value()).isEqualTo(30.15, within(0.01));
         }
     }
 

--- a/noakweather-platform/weather-processing/src/test/java/weather/processing/parser/noaa/NoaaMetarParserTest.java
+++ b/noakweather-platform/weather-processing/src/test/java/weather/processing/parser/noaa/NoaaMetarParserTest.java
@@ -3314,6 +3314,125 @@ class NoaaMetarParserTest {
         assertTrue(data.getRemarks().windShift().frontalPassage());
     }
 
+    // ========== WIND AT LOCATION TESTS (Issue #62) ==========
+
+    @Test
+    @DisplayName("Should parse single wind-at-altitude remark - ENSB real-world (Issue #62)")
+    void testParseWindAtLocation_SingleAltitude_ENSB() {
+        String metar = "METAR ENSB 042350Z 23012KT 7000 -SNRA SCT010 BKN020 02/M01 Q1003 RMK WIND 1400FT 23010KT";
+
+        ParseResult<NoaaWeatherData> result = parser.parse(metar);
+
+        assertTrue(result.isSuccess());
+        NoaaMetarData data = extractMetarData(result);
+
+        assertThat(data.getRemarks().windsAtLocation()).hasSize(1);
+        WindAtLocation wind = data.getRemarks().windsAtLocation().get(0);
+        assertThat(wind.isAtAltitude()).isTrue();
+        assertThat(wind.heightFeet()).isEqualTo(1400);
+        assertThat(wind.wind().directionDegrees()).isEqualTo(230);
+        assertThat(wind.wind().speedValue()).isEqualTo(10);
+        assertThat(wind.wind().unit()).isEqualTo("KT");
+
+        assertThat(data.getRemarks().freeText()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should parse chained runway and altitude wind remarks - ENSD real-world (Issue #62)")
+    void testParseWindAtLocation_ChainedRunwayAndAltitude_ENSD() {
+        String metar = "METAR ENSD 042350Z AUTO VRB01KT 9999 FEW075/// 10/09 Q0996 RMK WIND RWY 26 00000KT WIND 1126FT 00000KT";
+
+        ParseResult<NoaaWeatherData> result = parser.parse(metar);
+
+        assertTrue(result.isSuccess());
+        NoaaMetarData data = extractMetarData(result);
+
+        assertThat(data.getRemarks().windsAtLocation()).hasSize(2);
+
+        WindAtLocation runwayWind = data.getRemarks().windsAtLocation().get(0);
+        assertThat(runwayWind.isAtRunway()).isTrue();
+        assertThat(runwayWind.runway()).isEqualTo("26");
+        assertThat(runwayWind.wind().directionDegrees()).isZero();
+        assertThat(runwayWind.wind().speedValue()).isZero();
+
+        WindAtLocation altitudeWind = data.getRemarks().windsAtLocation().get(1);
+        assertThat(altitudeWind.isAtAltitude()).isTrue();
+        assertThat(altitudeWind.heightFeet()).isEqualTo(1126);
+        assertThat(altitudeWind.wind().directionDegrees()).isZero();
+        assertThat(altitudeWind.wind().speedValue()).isZero();
+
+        assertThat(data.getRemarks().freeText()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should parse single wind-at-altitude remark - ENSG real-world (Issue #62)")
+    void testParseWindAtLocation_SingleAltitude_ENSG() {
+        String metar = "METAR ENSG 042350Z AUTO VRB01KT 9999 SCT059/// BKN076/// OVC167/// 08/07 Q0996 RMK WIND 3806FT 18003KT";
+
+        ParseResult<NoaaWeatherData> result = parser.parse(metar);
+
+        assertTrue(result.isSuccess());
+        NoaaMetarData data = extractMetarData(result);
+
+        assertThat(data.getRemarks().windsAtLocation()).hasSize(1);
+        WindAtLocation wind = data.getRemarks().windsAtLocation().get(0);
+        assertThat(wind.isAtAltitude()).isTrue();
+        assertThat(wind.heightFeet()).isEqualTo(3806);
+        assertThat(wind.wind().directionDegrees()).isEqualTo(180);
+        assertThat(wind.wind().speedValue()).isEqualTo(3);
+
+        assertThat(data.getRemarks().freeText()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should parse single wind-at-altitude remark - ENSH real-world (Issue #62)")
+    void testParseWindAtLocation_SingleAltitude_ENSH() {
+        String metar = "METAR ENSH 042350Z 01012KT 9999 NCD 11/08 Q0999 RMK WIND 0150FT 02011KT";
+
+        ParseResult<NoaaWeatherData> result = parser.parse(metar);
+
+        assertTrue(result.isSuccess());
+        NoaaMetarData data = extractMetarData(result);
+
+        assertThat(data.getRemarks().windsAtLocation()).hasSize(1);
+        WindAtLocation wind = data.getRemarks().windsAtLocation().get(0);
+        assertThat(wind.isAtAltitude()).isTrue();
+        assertThat(wind.heightFeet()).isEqualTo(150);
+        assertThat(wind.wind().directionDegrees()).isEqualTo(20);
+        assertThat(wind.wind().speedValue()).isEqualTo(11);
+
+        assertThat(data.getRemarks().freeText()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should parse chained runway and altitude wind remarks with VRB direction - ENSR real-world (Issue #62)")
+    void testParseWindAtLocation_ChainedWithVrbDirection_ENSR() {
+        String metar = "METAR ENSR 042350Z AUTO 06002KT 9999 -DZ FEW007/// SCT012/// BKN019/// 08/06 Q1004 RMK WIND RWY 32 VRB01KT WIND 1119FT VRB03KT";
+
+        ParseResult<NoaaWeatherData> result = parser.parse(metar);
+
+        assertTrue(result.isSuccess());
+        NoaaMetarData data = extractMetarData(result);
+
+        assertThat(data.getRemarks().windsAtLocation()).hasSize(2);
+
+        WindAtLocation runwayWind = data.getRemarks().windsAtLocation().get(0);
+        assertThat(runwayWind.isAtRunway()).isTrue();
+        assertThat(runwayWind.runway()).isEqualTo("32");
+        assertThat(runwayWind.wind().directionDegrees()).isNull();
+        assertThat(runwayWind.wind().hasVariableDirection()).isTrue();
+        assertThat(runwayWind.wind().speedValue()).isEqualTo(1);
+
+        WindAtLocation altitudeWind = data.getRemarks().windsAtLocation().get(1);
+        assertThat(altitudeWind.isAtAltitude()).isTrue();
+        assertThat(altitudeWind.heightFeet()).isEqualTo(1119);
+        assertThat(altitudeWind.wind().directionDegrees()).isNull();
+        assertThat(altitudeWind.wind().hasVariableDirection()).isTrue();
+        assertThat(altitudeWind.wind().speedValue()).isEqualTo(3);
+
+        assertThat(data.getRemarks().freeText()).isNull();
+    }
+
     // ========== VARIABLE VISIBILITY PARSING TESTS ==========
 
     @ParameterizedTest
@@ -6082,8 +6201,49 @@ class NoaaMetarParserTest {
                 .isNull();
     }
 
+    // ========== SECONDARY ALTIMETER PARSING TESTS ==========
+
+    @ParameterizedTest
+    @CsvSource({
+            "29.77, 'METAR RPLL 020000Z 24010KT 8000 FEW025 SCT100 30/26 Q1008 NOSIG RMK A2977'",
+            "29.58, 'METAR RCTP 020000Z 03006KT 9999 FEW010 BKN180 28/26 Q1001 NOSIG RMK A2958'"
+    })
+    @DisplayName("Should parse secondary altimeter in remarks - real-world (Issue #56)")
+    void testParseSecondaryAltimeter(double expectedInHg, String metar) {
+        ParseResult<NoaaWeatherData> result = parser.parse(metar);
+
+        assertTrue(result.isSuccess());
+        NoaaMetarData data = extractMetarData(result);
+
+        assertThat(data.getRemarks().secondaryAltimeter()).isNotNull();
+        assertThat(data.getRemarks().secondaryAltimeter().value()).isEqualTo(expectedInHg, within(0.01));
+        assertThat(data.getRemarks().secondaryAltimeter().unit()).isEqualTo(PressureUnit.INCHES_HG);
+
+        assertThat(data.getRemarks().freeText()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should parse main-body and secondary altimeter independently - RPLL")
+    void testParseMainBodyAndSecondaryAltimeter_RPLL() {
+        String metar = "METAR RPLL 020000Z 24010KT 8000 FEW025 SCT100 30/26 Q1008 NOSIG RMK A2977";
+
+        ParseResult<NoaaWeatherData> result = parser.parse(metar);
+
+        assertTrue(result.isSuccess());
+        NoaaMetarData data = extractMetarData(result);
+
+        // Main body: Q1008 → hPa
+        assertThat(data.getPressure()).isNotNull();
+        assertThat(data.getPressure().value()).isEqualTo(1008.0, within(0.01));
+        assertThat(data.getPressure().unit()).isEqualTo(PressureUnit.HECTOPASCALS);
+
+        // Remarks: A2977 → inHg, separate field, doesn't overwrite main body
+        assertThat(data.getRemarks().secondaryAltimeter()).isNotNull();
+        assertThat(data.getRemarks().secondaryAltimeter().value()).isEqualTo(29.77, within(0.01));
+        assertThat(data.getRemarks().secondaryAltimeter().unit()).isEqualTo(PressureUnit.INCHES_HG);
+    }
+
     // ========== 6-HOUR MAX/MIN TEMPERATURE PARSING TESTS ==========
-// Add these tests to NoaaMetarParserTest.java after the Pressure Tendency tests
 
     @ParameterizedTest
     @CsvSource({

--- a/noakweather-platform/weather-storage/pom.xml
+++ b/noakweather-platform/weather-storage/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.19.1-SNAPSHOT</version>
+        <version>1.19.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-storage</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>weather</groupId>
     <artifactId>noakweather-engineering-pipeline</artifactId>
-    <version>1.19.1-SNAPSHOT</version>
+    <version>1.19.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>NoakWeather Engineering Pipeline Root</name>


### PR DESCRIPTION
#54, #56, #62

Bump version to 1.19.2-SNAPSHOT.

- PRESENT_WEATHER_PATTERN's precipitation/other groups legitimately accept a bare slash for partial-unknown codes, but this also let pure-slash tokens (//////, /////) — the ICAO missing-data convention — be parsed as real weather phenomena. Added a guard in the shared handlePresentWeather() (NoaaAviationWeatherParser, used by both METAR and TAF) to skip pure-slash tokens. Verified against the real-world MKJP UAT record. (#54)

- Relocated handleAltimeter()/parsePressure() and supporting helpers from NoaaMetarParser to NoaaAviationWeatherParser so NoaaTafParser can inherit them (TAF-side wiring deferred). Restored GROUP_PRESSURE_CHANGE to private static final after the move temporarily dropped its constant-ness (java:S116). Added direct unit tests in NoaaAviationWeatherParserTest, since prior coverage was only indirect via METAR integration tests.

- Philippines/Taiwan-region METARs (RPLL, RCTP) repeat the altimeter inside RMK in US-style A#### format as a redundant confirmation of the main body's ICAO reading. Fixed ALTIMETER_PATTERN's trailing mandatory whitespace (same last-token-in-string bug as DENSITY_ALTITUDE_PATTERN in #57). Added secondaryAltimeter (Pressure) to NoaaMetarRemarks, reusing the now-shared parsePressure() rather than duplicating conversion logic. Added handleSecondaryAltimeterSequential() in NoaaMetarParser. (#56)

- Norwegian/Arctic-region METARs (ENSB, ENSD, ENSG, ENSH, ENSR) report wind at a specific altitude or runway, distinct from surface wind, sometimes chained (multiple entries per remarks string) and sometimes using VRB direction. Added WindAtLocation record wrapping the existing Wind value object, WIND_AT_LOCATION_ PATTERN supporting both altitude and runway qualifiers, List WindAtLocation> windsAtLocation on NoaaMetarRemarks, and a loop-based handleWindAtLocationSequential()/ processWindAtLocationMatch() mirroring the established handleCloudTypeSequential chained-match pattern. (#62)

- Added WindAtLocationTest covering constructor validation, factory methods, getSummary(), and equality.

- Added real-world regression tests in NoaaMetarParserTest for all five Norwegian UAT stations, including chained runway+altitude and VRB direction cases.

- Added builder-level tests in NoaaMetarRemarksTest for secondaryAltimeter and windsAtLocation to close module-level coverage gaps (same class of gap fixed for densityAltitudeFeet under #57).

#54, #56, and #62 remain Pending UAT, not closed, pending a full UAT sweep re-run against the worldwide station set.