### PR TITLE
Add directional weather and PP precipitation group remarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,84 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Version 1.19.3-SNAPSHOT - September 8, 2026
+
+#### UAT Round 1 Remediation - Directional Weather and PP Precipitation Group (#60, #61)
+
+**Added:**
+- **Present-weather phenomenon restated in remarks with compass direction(s)**
+  (weather-common, weather-processing) (#60)
+  - Caribbean-region METARs (TNCM) restate a vicinity present-weather code
+    (e.g. `VCSH`) in remarks with one or more trailing compass directions
+    (`VCSH E SE`)
+  - Reuses the existing `PRESENT_WEATHER_PATTERN`/`PresentWeather.parse()`
+    rather than duplicating weather-code grammar.
+  - New `DirectionalWeather` record (`weather.model.components.remark`)
+    pairs a `PresentWeather` with an optional `List<String>` of directions;
+    a bare weather code with no trailing directions is still captured
+    (directions stays `null`) rather than falling through to `freeText`
+  - Added `DIRECTION_LIST_PATTERN` to `RegExprConst.java`
+  - Added `handleDirectionalWeatherSequential()` /
+    `processDirectionalWeatherMatch()` in `NoaaMetarParser`, deliberately
+    ordered **last** in the `handleRemarks()` chain since
+    `PRESENT_WEATHER_PATTERN` is broad/greedy and risks claiming tokens
+    meant for more specific handlers
+  - Fixed two real collisions surfaced by existing regression tests during
+    development:
+    - Bare `TS` (and `CB`/`TCU`/`ACC`/`CBMAM`/`VIRGA`) is ambiguous with
+      `TS_CLD_LOC_PATTERN`'s thunderstorm-location remarks (e.g. `TS SE`);
+      excluded these codes from directional-weather matching when they
+      appear with no other present-weather qualifiers, deferring to the
+      established thunderstorm-location handler
+    - `PRESENT_WEATHER_PATTERN`'s mandatory trailing whitespace (same
+      last-token-in-string bug pattern as #56/#57) meant a bare trailing
+      code (`RMK VCSH`, nothing after it) wouldn't match at all; worked
+      around locally in the remarks handler via a synthetic trailing-space
+      pad, without modifying the shared main-body pattern
+
+- **"PP" precipitation-amount group** (weather-common, weather-processing) (#61)
+  - South American METARs (SPJC) report precipitation via a `PP` + 3-digit
+    group (`PP000`), distinct from the existing US-style single-`P` hourly
+    group
+  - Format/unit/scale and time period could not be confirmed via available
+    research; rather than guess and risk a silently-wrong conversion
+    (`PrecipitationAmount`'s `periodHours` is a validated, non-nullable
+    `int` restricted to `{1, 3, 6, 24}` — no honest way to represent an
+    unknown period), the raw 3-digit value is captured as-is on a new
+    `ppGroupValue` (`Integer`) field, named after the literal token rather
+    than the region or an assumed unit, pending further research
+  - Added `PP_GROUP_PATTERN` to `RegExprConst.java` and
+    `handlePpGroupSequential()` in `NoaaMetarParser`, positioned between
+    the existing hourly and multi-hour precipitation handlers
+
+**Fixed:**
+- **`DIRECTION_LIST_PATTERN` catastrophic-backtracking risk** (weather-processing)
+  (java:S5998) — the repeating compass-direction group used an ordinary
+  (backtracking) quantifier over an alternation with shared prefixes
+  (`N`/`NE`/`NW`, `S`/`SE`/`SW`); changed to a possessive quantifier,
+  consistent with the existing fix in `PRESENT_WEATHER_PATTERN`
+
+**Testing:**
+- Added `DirectionalWeatherTest.java` covering constructor validation,
+  `hasDirections()`, `getSummary()`, and equality
+- Added real-world regression tests in `NoaaMetarParserTest` for TNCM
+  (with and without trailing directions) and SPJC (`PP000`, a non-zero
+  value, and alongside a standard `P####` group to confirm no collision)
+- Added builder-level tests in `NoaaMetarRemarksTest` for `directionalWeather`
+  and `ppGroupValue`
+- Full reactor build (`wethb.sh` + `wetht.sh`) passing across all modules
+
+**Notes:**
+- Issues #60 and #61 are marked **Pending UAT** rather than Done — verified
+  via unit tests and code review, not yet confirmed against the full
+  worldwide UAT station corpus.
+- Issue #63 (observation year not parsed from NOAA's source header line)
+  was investigated but deferred to its own branch: the fix requires
+  relocating TAF's existing `parseIssueDateTime()` mechanism to the shared
+  `NoaaAviationWeatherParser` base class so METAR and TAF consume the
+  identical header-line format consistently, rather than METAR growing a
+  separate, possibly-divergent implementation.
+
 ### Version 1.19.2-SNAPSHOT - September 6, 2026
 
 #### UAT Round 1 Remediation - Present Weather, Secondary Altimeter, and Wind at Location (#54, #56, #62)

--- a/noakweather-platform/pom.xml
+++ b/noakweather-platform/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>weather</groupId>
     <artifactId>noakweather-platform</artifactId>
-    <version>1.19.2-SNAPSHOT</version>
+    <version>1.19.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>NoakWeather Engineering Pipeline</name>

--- a/noakweather-platform/weather-analytics/pom.xml
+++ b/noakweather-platform/weather-analytics/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.19.2-SNAPSHOT</version>
+        <version>1.19.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-analytics</artifactId>

--- a/noakweather-platform/weather-common/pom.xml
+++ b/noakweather-platform/weather-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.19.2-SNAPSHOT</version>
+        <version>1.19.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-common</artifactId>

--- a/noakweather-platform/weather-common/src/main/java/weather/model/components/remark/DirectionalWeather.java
+++ b/noakweather-platform/weather-common/src/main/java/weather/model/components/remark/DirectionalWeather.java
@@ -1,0 +1,56 @@
+package weather.model.components.remark;
+
+import weather.model.components.PresentWeather;
+
+import java.util.List;
+
+/**
+ * Immutable value object representing a present-weather phenomenon reported
+ * in remarks, optionally with associated compass direction(s), typically
+ * restating a vicinity or nearby-occurring phenomenon.
+ * <p>
+ * Examples:
+ * - "VCSH E SE" → DirectionalWeather(PresentWeather("VCSH"), ["E", "SE"])
+ * - "VCSH" → DirectionalWeather(PresentWeather("VCSH"), null)
+ *
+ * @param presentWeather The present-weather phenomenon (reuses existing PresentWeather parsing)
+ * @param directions One or more compass directions associated with the phenomenon, or null if none given
+ *
+ * @author bclasky1539
+ *
+ */
+public record DirectionalWeather(
+        PresentWeather presentWeather,
+        List<String> directions
+) {
+
+    /**
+     * Compact constructor with validation and defensive copying.
+     */
+    public DirectionalWeather {
+        if (presentWeather == null) {
+            throw new IllegalArgumentException("Present weather cannot be null");
+        }
+        directions = directions != null && !directions.isEmpty() ? List.copyOf(directions) : null;
+    }
+
+    /**
+     * Check if direction information is present.
+     *
+     * @return true if one or more directions are recorded
+     */
+    public boolean hasDirections() {
+        return directions != null;
+    }
+
+    /**
+     * Get a human-readable summary.
+     * Examples: "Showers in vicinity: E, SE", "Showers in vicinity"
+     *
+     * @return formatted summary string
+     */
+    public String getSummary() {
+        String base = presentWeather.getDescription();
+        return hasDirections() ? base + ": " + String.join(", ", directions) : base;
+    }
+}

--- a/noakweather-platform/weather-common/src/main/java/weather/model/components/remark/NoaaMetarRemarks.java
+++ b/noakweather-platform/weather-common/src/main/java/weather/model/components/remark/NoaaMetarRemarks.java
@@ -44,6 +44,7 @@ import java.util.stream.Collectors;
  * * @param peakWind Peak wind information
  * * @param windShift Wind shift information
  * * @param windsAtLocation Winds at a location
+ * * @param DirectionalWeather Directional Weather
  * * @param variableVisibility Variable visibility data
  * * @param CeilingSecondSite Ceiling height at second observation site
  * * @param obscurationLayers Obscuration Layer information
@@ -51,6 +52,9 @@ import java.util.stream.Collectors;
  * * @param towerVisibility Tower visibility (if different from surface)
  * * @param surfaceVisibility Surface visibility (if different from prevailing)
  * * @param hourlyPrecipitation Hourly precipitation amount (P)
+ * * @param ppGroupValue Raw value from "PP" precipitation-amount group; unit/scale
+ * *                      and time period unconfirmed, captured as-is pending
+ * *                      further research
  * * @param precipitation3Hour 3-hour precipitation amount
  * * @param precipitation6Hour 6-hour precipitation amount
  * * @param precipitation24Hour 24-hour precipitation amount
@@ -80,6 +84,7 @@ public record NoaaMetarRemarks(
         PeakWind peakWind,
         WindShift windShift,
         List<WindAtLocation> windsAtLocation,
+        DirectionalWeather directionalWeather,
         VariableVisibility variableVisibility,
         VariableCeiling variableCeiling,
         CeilingSecondSite ceilingSecondSite,
@@ -88,6 +93,7 @@ public record NoaaMetarRemarks(
         Visibility towerVisibility,
         Visibility surfaceVisibility,
         PrecipitationAmount hourlyPrecipitation,
+        Integer ppGroupValue,
         PrecipitationAmount sixHourPrecipitation,
         PrecipitationAmount twentyFourHourPrecipitation,
         HailSize hailSize,
@@ -127,8 +133,8 @@ public record NoaaMetarRemarks(
      */
     public static NoaaMetarRemarks empty() {
         return new NoaaMetarRemarks(null, null, null, null,
-                null, null, List.of(), null, null, null, List.of(),
-                List.of(), null, null, null, null,
+                null, null, List.of(), null,null, null, null,
+                List.of(), List.of(), null, null, null, null, null,
                 null, null, List.of(), List.of(), null,
                 null, null, null, null,
                 null, null, List.of(), null, null);
@@ -147,6 +153,7 @@ public record NoaaMetarRemarks(
                 && peakWind == null
                 && windShift == null
                 && (windsAtLocation == null || windsAtLocation.isEmpty())
+                && (directionalWeather == null)
                 && variableVisibility == null
                 && variableCeiling == null
                 && ceilingSecondSite == null
@@ -155,6 +162,7 @@ public record NoaaMetarRemarks(
                 && towerVisibility == null
                 && surfaceVisibility == null
                 && hourlyPrecipitation == null
+                && ppGroupValue == null
                 && sixHourPrecipitation == null
                 && twentyFourHourPrecipitation == null
                 && hailSize == null
@@ -203,6 +211,7 @@ public record NoaaMetarRemarks(
         private PeakWind peakWind;
         private WindShift windShift;
         private List<WindAtLocation> windsAtLocation = new ArrayList<>();
+        private DirectionalWeather directionalWeather;
         private VariableVisibility variableVisibility;
         private VariableCeiling variableCeiling;
         private CeilingSecondSite ceilingSecondSite;
@@ -211,6 +220,7 @@ public record NoaaMetarRemarks(
         private Visibility towerVisibility;
         private Visibility surfaceVisibility;
         private PrecipitationAmount hourlyPrecipitation;
+        private Integer ppGroupValue;
         private PrecipitationAmount sixHourPrecipitation;
         private PrecipitationAmount twentyFourHourPrecipitation;
         private HailSize hailSize;
@@ -331,6 +341,19 @@ public record NoaaMetarRemarks(
             if (windsAtLocation != null) {
                 this.windsAtLocation.addAll(windsAtLocation);
             }
+            return this;
+        }
+
+        /**
+         * Sets the present-weather phenomenon reported in remarks with optional
+         * compass direction(s), typically restating a vicinity or nearby-occurring
+         * phenomenon (e.g. VCSH E SE).
+         *
+         * @param directionalWeather the directional weather remark
+         * @return this builder
+         */
+        public Builder directionalWeather(DirectionalWeather directionalWeather) {
+            this.directionalWeather = directionalWeather;
             return this;
         }
 
@@ -471,6 +494,21 @@ public record NoaaMetarRemarks(
          */
         public Builder hourlyPrecipitation(PrecipitationAmount hourlyPrecipitation) {
             this.hourlyPrecipitation = hourlyPrecipitation;
+            return this;
+        }
+
+        /**
+         * Sets the raw value from the "PP" precipitation-amount group.
+         * Format, unit/scale, and time period are not fully confirmed at this
+         * time — the value is captured as-is (raw 3-digit integer) pending
+         * further research. Distinct from the standard single-P hourly
+         * precipitation group (see PrecipitationAmount).
+         *
+         * @param ppGroupValue the raw PP group value
+         * @return this builder
+         */
+        public Builder ppGroupValue(Integer ppGroupValue) {
+            this.ppGroupValue = ppGroupValue;
             return this;
         }
 
@@ -706,6 +744,7 @@ public record NoaaMetarRemarks(
                     peakWind,
                     windShift,
                     List.copyOf(windsAtLocation),
+                    directionalWeather,
                     variableVisibility,
                     variableCeiling,
                     ceilingSecondSite,
@@ -714,6 +753,7 @@ public record NoaaMetarRemarks(
                     towerVisibility,
                     surfaceVisibility,
                     hourlyPrecipitation,
+                    ppGroupValue,
                     sixHourPrecipitation,
                     twentyFourHourPrecipitation,
                     hailSize,
@@ -754,6 +794,7 @@ public record NoaaMetarRemarks(
                     .map(WindAtLocation::getSummary)
                     .collect(Collectors.joining("; ")));
         }
+        addIfPresent(parts, directionalWeather, "directionalWeather", DirectionalWeather::getSummary);
         addIfPresent(parts, variableVisibility, "variableVisibility", Object::toString);
         addIfPresent(parts, variableCeiling, "variableCeiling", VariableCeiling::getSummary);
         addIfPresent(parts, ceilingSecondSite, "ceilingSecondSite", CeilingSecondSite::getSummary);
@@ -770,6 +811,7 @@ public record NoaaMetarRemarks(
         addIfPresent(parts, towerVisibility, "towerVisibility", Visibility::getSummary);
         addIfPresent(parts, surfaceVisibility, "surfaceVisibility", Visibility::getSummary);
         addIfPresent(parts, hourlyPrecipitation, "hourlyPrecip", PrecipitationAmount::getDescription);
+        addIfPresent(parts, ppGroupValue, "ppGroupValue", Object::toString);
         addIfPresent(parts, sixHourPrecipitation, "sixHourPrecip", PrecipitationAmount::getDescription);
         addIfPresent(parts, twentyFourHourPrecipitation, "twentyFourHourPrecip", PrecipitationAmount::getDescription);
         addIfPresent(parts, hailSize, "hailSize", HailSize::getSummary);

--- a/noakweather-platform/weather-common/src/test/java/weather/model/components/remark/DirectionalWeatherTest.java
+++ b/noakweather-platform/weather-common/src/test/java/weather/model/components/remark/DirectionalWeatherTest.java
@@ -1,0 +1,177 @@
+/*
+ * NoakWeather Engineering Pipeline(TM) is a multi-source weather data engineering platform
+ * Copyright (C) 2025 bclasky1539
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package weather.model.components.remark;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import weather.model.components.PresentWeather;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for DirectionalWeather.
+ *
+ * @author bclasky1539
+ *
+ */
+class DirectionalWeatherTest {
+
+    @Test
+    @DisplayName("Should create directional weather with directions via canonical constructor")
+    void testConstructor_WithDirections() {
+        PresentWeather weather = PresentWeather.parse("VCSH");
+        List<String> directions = List.of("E", "SE");
+
+        DirectionalWeather directionalWeather = new DirectionalWeather(weather, directions);
+
+        assertThat(directionalWeather.presentWeather()).isEqualTo(weather);
+        assertThat(directionalWeather.directions()).containsExactly("E", "SE");
+    }
+
+    @Test
+    @DisplayName("Should create directional weather with null directions via canonical constructor")
+    void testConstructor_NullDirections() {
+        PresentWeather weather = PresentWeather.parse("VCSH");
+
+        DirectionalWeather directionalWeather = new DirectionalWeather(weather, null);
+
+        assertThat(directionalWeather.presentWeather()).isEqualTo(weather);
+        assertThat(directionalWeather.directions()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should normalize empty directions list to null")
+    void testConstructor_EmptyDirectionsNormalizedToNull() {
+        PresentWeather weather = PresentWeather.parse("VCSH");
+
+        DirectionalWeather directionalWeather = new DirectionalWeather(weather, List.of());
+
+        assertThat(directionalWeather.directions()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should throw when presentWeather is null")
+    void testConstructor_NullPresentWeather_Throws() {
+        List<String> directions = List.of("E");
+
+        assertThatThrownBy(() -> new DirectionalWeather(null, directions))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Present weather cannot be null");
+    }
+
+    @Test
+    @DisplayName("Should make defensive copy of directions list")
+    void testConstructor_DefensiveCopyOfDirections() {
+        PresentWeather weather = PresentWeather.parse("VCSH");
+        List<String> originalList = new ArrayList<>();
+        originalList.add("E");
+
+        DirectionalWeather directionalWeather = new DirectionalWeather(weather, originalList);
+
+        originalList.add("SE");
+
+        assertThat(directionalWeather.directions()).containsExactly("E");
+    }
+
+    @Test
+    @DisplayName("hasDirections should return true when directions are present")
+    void testHasDirections_True() {
+        DirectionalWeather directionalWeather = new DirectionalWeather(
+                PresentWeather.parse("VCSH"), List.of("E", "SE"));
+
+        assertThat(directionalWeather.hasDirections()).isTrue();
+    }
+
+    @Test
+    @DisplayName("hasDirections should return false when directions are null")
+    void testHasDirections_False() {
+        DirectionalWeather directionalWeather = new DirectionalWeather(
+                PresentWeather.parse("VCSH"), null);
+
+        assertThat(directionalWeather.hasDirections()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should generate correct summary with directions")
+    void testGetSummary_WithDirections() {
+        DirectionalWeather directionalWeather = new DirectionalWeather(
+                PresentWeather.parse("VCSH"), List.of("E", "SE"));
+
+        assertThat(directionalWeather.getSummary())
+                .isEqualTo(PresentWeather.parse("VCSH").getDescription() + ": E, SE");
+    }
+
+    @Test
+    @DisplayName("Should generate correct summary without directions")
+    void testGetSummary_WithoutDirections() {
+        DirectionalWeather directionalWeather = new DirectionalWeather(
+                PresentWeather.parse("VCSH"), null);
+
+        assertThat(directionalWeather.getSummary())
+                .isEqualTo(PresentWeather.parse("VCSH").getDescription());
+    }
+
+    @Test
+    @DisplayName("Should be equal when presentWeather and directions match")
+    void testEquality() {
+        DirectionalWeather directionalWeather1 = new DirectionalWeather(
+                PresentWeather.parse("VCSH"), List.of("E", "SE"));
+        DirectionalWeather directionalWeather2 = new DirectionalWeather(
+                PresentWeather.parse("VCSH"), List.of("E", "SE"));
+
+        assertThat(directionalWeather1)
+                .isEqualTo(directionalWeather2)
+                .hasSameHashCodeAs(directionalWeather2);
+    }
+
+    @Test
+    @DisplayName("Should not be equal when directions differ")
+    void testInequality_DifferentDirections() {
+        DirectionalWeather directionalWeather1 = new DirectionalWeather(
+                PresentWeather.parse("VCSH"), List.of("E", "SE"));
+        DirectionalWeather directionalWeather2 = new DirectionalWeather(
+                PresentWeather.parse("VCSH"), List.of("N", "NE"));
+
+        assertThat(directionalWeather1).isNotEqualTo(directionalWeather2);
+    }
+
+    @Test
+    @DisplayName("Should not be equal when presentWeather differs")
+    void testInequality_DifferentPresentWeather() {
+        DirectionalWeather directionalWeather1 = new DirectionalWeather(
+                PresentWeather.parse("VCSH"), List.of("E"));
+        DirectionalWeather directionalWeather2 = new DirectionalWeather(
+                PresentWeather.parse("TSRA"), List.of("E"));
+
+        assertThat(directionalWeather1).isNotEqualTo(directionalWeather2);
+    }
+
+    @Test
+    @DisplayName("Should not be equal when one has directions and the other does not")
+    void testInequality_OneWithDirectionsOneWithout() {
+        DirectionalWeather directionalWeather1 = new DirectionalWeather(
+                PresentWeather.parse("VCSH"), List.of("E"));
+        DirectionalWeather directionalWeather2 = new DirectionalWeather(
+                PresentWeather.parse("VCSH"), null);
+
+        assertThat(directionalWeather1).isNotEqualTo(directionalWeather2);
+    }
+}

--- a/noakweather-platform/weather-common/src/test/java/weather/model/components/remark/NoaaMetarRemarksTest.java
+++ b/noakweather-platform/weather-common/src/test/java/weather/model/components/remark/NoaaMetarRemarksTest.java
@@ -20,10 +20,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import weather.model.components.Pressure;
-import weather.model.components.Temperature;
-import weather.model.components.Visibility;
-import weather.model.components.Wind;
+import weather.model.components.*;
 import weather.model.enums.AutomatedStationType;
 
 import java.util.ArrayList;
@@ -169,9 +166,9 @@ class NoaaMetarRemarksTest {
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 stationType, slp, temp, dewpoint, null, null, null, null,
+                null,null, null, null, null, null,
                 null, null, null, null, null,
                 null, null, null, null, null,
-                null, null, null, null,
                 null, null, null, null,
                 null, null, null, freeText
         );
@@ -263,7 +260,6 @@ class NoaaMetarRemarksTest {
     }
 
     // ========== Tests for isEmpty() edge cases ==========
-    // ========== Tests for isEmpty() edge cases ==========
 
     @Test
     void testIsEmptyWithOnlySeaLevelPressure() {
@@ -342,10 +338,10 @@ class NoaaMetarRemarksTest {
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, peakWind,
-                null, null, null, null, null,
+                null, null, null,null, null, null,
                 null, null, null, null,
+                null, null,null, null, null,
                 null, null, null, null, null,
-                null, null, null, null,
                 null, null, null,
                 null, null, null, null
         );
@@ -360,10 +356,10 @@ class NoaaMetarRemarksTest {
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
-                windShift, null,null, null, null, null,
-                null, null, null,
-                null, null, null, null, null,
+                windShift, null, null,null, null, null,
                 null, null, null, null,
+                null, null, null, null, null,
+                null, null, null, null, null,
                 null, null, null,
                 null, null, null, null
         );
@@ -620,6 +616,131 @@ class NoaaMetarRemarksTest {
         assertNotEquals(remarks1, remarks2);
     }
 
+    // ========== DIRECTIONAL WEATHER TESTS ==========
+
+    @Test
+    @DisplayName("Should not be empty when only directionalWeather is present")
+    void testIsEmptyWithOnlyDirectionalWeather() {
+        DirectionalWeather directionalWeather = new DirectionalWeather(
+                PresentWeather.parse("VCSH"), List.of("E", "SE"));
+
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .directionalWeather(directionalWeather)
+                .build();
+
+        assertFalse(remarks.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should build remarks with directionalWeather via builder")
+    void testBuilder_DirectionalWeather() {
+        DirectionalWeather directionalWeather = new DirectionalWeather(
+                PresentWeather.parse("VCSH"), List.of("E", "SE"));
+
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .directionalWeather(directionalWeather)
+                .build();
+
+        assertThat(remarks.directionalWeather()).isEqualTo(directionalWeather);
+        assertThat(remarks.isEmpty()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should handle null directionalWeather via builder")
+    void testBuilder_NullDirectionalWeather() {
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .directionalWeather(null)
+                .build();
+
+        assertThat(remarks.directionalWeather()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should build remarks with directionalWeather having no directions")
+    void testBuilder_DirectionalWeatherNoDirections() {
+        DirectionalWeather directionalWeather = new DirectionalWeather(
+                PresentWeather.parse("VCSH"), null);
+
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .directionalWeather(directionalWeather)
+                .build();
+
+        assertThat(remarks.directionalWeather()).isEqualTo(directionalWeather);
+        assertThat(remarks.directionalWeather().hasDirections()).isFalse();
+        assertThat(remarks.isEmpty()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should build remarks with multiple fields including directionalWeather")
+    void testBuilder_MultipleFieldsIncludingDirectionalWeather() {
+        AutomatedStationType stationType = AutomatedStationType.AO2;
+        Pressure slp = Pressure.hectopascals(1013.2);
+        DirectionalWeather directionalWeather = new DirectionalWeather(
+                PresentWeather.parse("VCSH"), List.of("E", "SE"));
+
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .automatedStationType(stationType)
+                .seaLevelPressure(slp)
+                .directionalWeather(directionalWeather)
+                .build();
+
+        assertThat(remarks.automatedStationType()).isEqualTo(stationType);
+        assertThat(remarks.seaLevelPressure()).isEqualTo(slp);
+        assertThat(remarks.directionalWeather()).isEqualTo(directionalWeather);
+        assertThat(remarks.isEmpty()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should include directionalWeather in toString()")
+    void testToString_DirectionalWeather() {
+        DirectionalWeather directionalWeather = new DirectionalWeather(
+                PresentWeather.parse("VCSH"), List.of("E", "SE"));
+
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .directionalWeather(directionalWeather)
+                .build();
+
+        String str = remarks.toString();
+        assertThat(str)
+                .contains("directionalWeather")
+                .contains("E, SE");
+    }
+
+    @Test
+    @DisplayName("Should be equal when directionalWeather is the same")
+    void testEqualityWithDirectionalWeather() {
+        DirectionalWeather directionalWeather = new DirectionalWeather(
+                PresentWeather.parse("VCSH"), List.of("E", "SE"));
+
+        NoaaMetarRemarks remarks1 = NoaaMetarRemarks.builder()
+                .automatedStationType(AutomatedStationType.AO2)
+                .directionalWeather(directionalWeather)
+                .build();
+
+        NoaaMetarRemarks remarks2 = NoaaMetarRemarks.builder()
+                .automatedStationType(AutomatedStationType.AO2)
+                .directionalWeather(directionalWeather)
+                .build();
+
+        assertThat(remarks1)
+                .isEqualTo(remarks2)
+                .hasSameHashCodeAs(remarks2);
+    }
+
+    @Test
+    @DisplayName("Should not be equal when directionalWeather differs")
+    void testInequalityWithDifferentDirectionalWeather() {
+        NoaaMetarRemarks remarks1 = NoaaMetarRemarks.builder()
+                .directionalWeather(new DirectionalWeather(PresentWeather.parse("VCSH"), List.of("E", "SE")))
+                .build();
+
+        NoaaMetarRemarks remarks2 = NoaaMetarRemarks.builder()
+                .directionalWeather(new DirectionalWeather(PresentWeather.parse("VCSH"), List.of("N", "NW")))
+                .build();
+
+        assertNotEquals(remarks1, remarks2);
+    }
+
     // ========== Tests for isEmpty() with VariableVisibility ==========
 
     @Test
@@ -658,10 +779,10 @@ class NoaaMetarRemarksTest {
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
-                null, null, varVis, null, null, null,
-                null, null, null,
-                null, null, null, null, null,
+                null, null, null, varVis, null, null,
                 null, null, null, null,
+                null, null, null, null, null,
+                null, null, null, null, null,
                 null, null, null,
                 null, null, null, null
         );
@@ -864,9 +985,9 @@ class NoaaMetarRemarksTest {
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
+                null, null, null,null, null, null,
+                null, null, towerVis, null,
                 null, null, null, null, null, null,
-                null, towerVis, null,
-                null, null, null, null, null,
                 null, null, null, null,
                 null, null, null,
                 null, null, null, null
@@ -883,9 +1004,9 @@ class NoaaMetarRemarksTest {
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
+                null, null, null,null, null, null,
+                null, null, null, surfaceVis,
                 null, null, null, null, null, null,
-                null, null, surfaceVis,
-                null, null, null, null, null,
                 null, null, null, null,
                 null, null, null,
                 null, null, null, null
@@ -903,9 +1024,9 @@ class NoaaMetarRemarksTest {
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
+                null, null, null,null, null, null,
+                null, null, towerVis, surfaceVis,
                 null, null, null, null, null, null,
-                null, towerVis, surfaceVis,
-                null, null, null, null, null,
                 null, null, null, null,
                 null, null, null,
                 null, null, null, null
@@ -1113,8 +1234,8 @@ class NoaaMetarRemarksTest {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
                 null, null, null, null, null, null,
-                null, null, null,
-                hourly, null, null, null, null, null,
+                null, null, null, null,
+                hourly, null, null, null, null, null, null,
                 null, null, null, null,
                 null, null, null, null,
                 null, null
@@ -1133,7 +1254,7 @@ class NoaaMetarRemarksTest {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
                 null, null, null, null, null, null,
-                null, null, null,
+                null, null, null, null, null,
                 null, sixHour, null, null, null, null,
                 null, null, null, null,
                 null, null, null, null,
@@ -1153,9 +1274,9 @@ class NoaaMetarRemarksTest {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
                 null, null, null, null, null, null,
-                null, null, null,
-                null, null, twentyFourHour, null, null, null,
                 null, null, null, null,
+                null, null, null, twentyFourHour, null, null,
+                null, null, null, null, null,
                 null, null, null, null,
                 null, null
         );
@@ -1175,8 +1296,8 @@ class NoaaMetarRemarksTest {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
                 null, null, null, null, null, null,
-                null, null, null,
-                hourly, sixHour, twentyFourHour, null, null, null,
+                null, null, null, null,
+                hourly, null, sixHour, twentyFourHour, null, null, null,
                 null, null, null, null,
                 null, null, null, null,
                 null, null
@@ -1423,8 +1544,8 @@ class NoaaMetarRemarksTest {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
                 null, null, null, null, null, null,
-                null, null, null,
-                null, null, null, hailSize, null,
+                null, null, null, null,
+                null, null, null, null, hailSize, null,
                 null, null, null, null,
                 null, null, null,
                 null, null, null, null
@@ -1439,8 +1560,8 @@ class NoaaMetarRemarksTest {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
                 null, null, null, null, null, null,
-                null, null, null,
-                null, null, null, null, null,
+                null, null, null, null,
+                null, null, null, null, null, null,
                 null, null, null, null,
                 null, null, null,
                 null, null, null, null
@@ -1642,8 +1763,8 @@ class NoaaMetarRemarksTest {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
                 null, null, null, null, null, null,
-                null, null, null,
-                null, null, null, null, null,
+                null, null, null, null,
+                null, null, null, null, null, null,
                 List.of(location), null, null, null,
                 null, null, null,
                 null, null, null, null
@@ -1662,8 +1783,8 @@ class NoaaMetarRemarksTest {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
                 null, null, null, null, null, null,
-                null, null, null,
-                null, null, null, null, null,
+                null, null, null, null,
+                null, null, null, null, null, null,
                 List.of(location1, location2), null, null, null,
                 null, null, null,
                 null, null, null, null
@@ -2042,8 +2163,8 @@ class NoaaMetarRemarksTest {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
                 null, null, null, null, null, null,
-                null, null, null,
-                null, null, null, null, List.of(event),
+                null, null, null, null,
+                null, null, null, null, null, List.of(event),
                 null, null, null, null,
                 null, null, null,
                 null, null, null, null
@@ -2062,8 +2183,8 @@ class NoaaMetarRemarksTest {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
                 null, null, null, null, null, null,
-                null, null, null,
-                null, null, null, null, List.of(event1, event2),
+                null, null, null, null,
+                null, null, null, null, null, List.of(event1, event2),
                 null, null, null, null,
                 null, null, null,
                 null, null, null, null
@@ -2448,8 +2569,8 @@ class NoaaMetarRemarksTest {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
                 null, null, null, null, null, null,
-                null, null, null,
-                null, null, null, null, null,
+                null, null, null, null,
+                null, null, null, null, null, null,
                 null, tendency, null, null,
                 null, null, null,
                 null, null, null, null
@@ -2463,9 +2584,9 @@ class NoaaMetarRemarksTest {
     void testRecordConstructorWithNullPressureTendency() {
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
                 null, null, null, null, null,
-                null, null,null, null, null, null,
-                null, null, null,
-                null, null, null, null, null,
+                null, null, null, null, null, null,
+                null, null, null, null,
+                null, null, null, null, null, null,
                 null, null, null, null,
                 null, null, null,
                 null, null, null, null
@@ -3668,6 +3789,100 @@ class NoaaMetarRemarksTest {
         assertThat(str).contains("densityAltitudeFeet=1500");
     }
 
+    // ========== PP GROUP VALUE TESTS ==========
+
+    @Test
+    @DisplayName("Should not be empty when only ppGroupValue is present")
+    void testIsEmptyWithOnlyPpGroupValue() {
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .ppGroupValue(0)
+                .build();
+
+        assertFalse(remarks.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should build remarks with ppGroupValue via builder")
+    void testBuilder_PpGroupValue() {
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .ppGroupValue(0)
+                .build();
+
+        assertThat(remarks.ppGroupValue()).isZero();
+        assertThat(remarks.isEmpty()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should handle null ppGroupValue via builder")
+    void testBuilder_NullPpGroupValue() {
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .ppGroupValue(null)
+                .build();
+
+        assertThat(remarks.ppGroupValue()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should build remarks with multiple fields including ppGroupValue")
+    void testBuilder_MultipleFieldsIncludingPpGroupValue() {
+        AutomatedStationType stationType = AutomatedStationType.AO2;
+        Pressure slp = Pressure.hectopascals(1013.2);
+
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .automatedStationType(stationType)
+                .seaLevelPressure(slp)
+                .ppGroupValue(102)
+                .build();
+
+        assertThat(remarks.automatedStationType()).isEqualTo(stationType);
+        assertThat(remarks.seaLevelPressure()).isEqualTo(slp);
+        assertThat(remarks.ppGroupValue()).isEqualTo(102);
+        assertThat(remarks.isEmpty()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should include ppGroupValue in toString()")
+    void testToString_PpGroupValue() {
+        NoaaMetarRemarks remarks = NoaaMetarRemarks.builder()
+                .ppGroupValue(0)
+                .build();
+
+        String str = remarks.toString();
+        assertThat(str).contains("ppGroupValue=0");
+    }
+
+    @Test
+    @DisplayName("Should be equal when ppGroupValue is the same")
+    void testEqualityWithPpGroupValue() {
+        NoaaMetarRemarks remarks1 = NoaaMetarRemarks.builder()
+                .automatedStationType(AutomatedStationType.AO2)
+                .ppGroupValue(0)
+                .build();
+
+        NoaaMetarRemarks remarks2 = NoaaMetarRemarks.builder()
+                .automatedStationType(AutomatedStationType.AO2)
+                .ppGroupValue(0)
+                .build();
+
+        assertThat(remarks1)
+                .isEqualTo(remarks2)
+                .hasSameHashCodeAs(remarks2);
+    }
+
+    @Test
+    @DisplayName("Should not be equal when ppGroupValue differs")
+    void testInequalityWithDifferentPpGroupValue() {
+        NoaaMetarRemarks remarks1 = NoaaMetarRemarks.builder()
+                .ppGroupValue(0)
+                .build();
+
+        NoaaMetarRemarks remarks2 = NoaaMetarRemarks.builder()
+                .ppGroupValue(102)
+                .build();
+
+        assertNotEquals(remarks1, remarks2);
+    }
+
     // ========== CORRECTED TESTS FOR NoaaMetarRemarksTest.java ==========
 
     @Test
@@ -4236,6 +4451,10 @@ class NoaaMetarRemarksTest {
                 WindAtLocation.atAltitude(1400, Wind.of(230, 10, "KT")),
                 WindAtLocation.atRunway("26", Wind.calm())
         );
+        DirectionalWeather directionalWeather = new DirectionalWeather(
+                PresentWeather.parse("VCSH"),
+                List.of("E", "SE")
+        );
         Visibility min = Visibility.statuteMiles(0.5);
         Visibility max = Visibility.statuteMiles(2.0);
         VariableVisibility varVis = new VariableVisibility(min, max, null, null);
@@ -4252,6 +4471,7 @@ class NoaaMetarRemarksTest {
         Visibility towerVis = Visibility.statuteMiles(1.5);
         Visibility surfaceVis = Visibility.statuteMiles(0.75);
         PrecipitationAmount hourly = PrecipitationAmount.fromEncoded("0015", 1);
+        Integer ppGroupValue = 102;
         PrecipitationAmount sixHour = PrecipitationAmount.fromEncoded("0025", 6);
         PrecipitationAmount twentyFourHour = PrecipitationAmount.fromEncoded("0125", 24);
         HailSize hailSize = HailSize.inches(1.75);
@@ -4276,13 +4496,13 @@ class NoaaMetarRemarksTest {
         String freeText = "Additional remarks";
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
-                stationType, slp, temp, dewpoint, peakWind, windShift, windsAtLocation, varVis, variableCeiling, ceilingSecondSite,
-                obscurationLayers, cloudTypes, towerVis, surfaceVis, hourly, sixHour, twentyFourHour, hailSize, weatherEvents,
-                thunderstormLocations, tendency, secondaryAltimeter, sixHourMaxTemp, sixHourMinTemp, twentyFourHourMaxTemp,
+                stationType, slp, temp, dewpoint, peakWind, windShift, windsAtLocation, directionalWeather, varVis, variableCeiling,
+                ceilingSecondSite, obscurationLayers, cloudTypes, towerVis, surfaceVis, hourly, ppGroupValue, sixHour, twentyFourHour, hailSize,
+                weatherEvents, thunderstormLocations, tendency, secondaryAltimeter, sixHourMaxTemp, sixHourMinTemp, twentyFourHourMaxTemp,
                 twentyFourHourMinTemp, densityAltitudeFeet, automatedMaintenanceIndicators, maintenanceRequired, freeText
         );
 
-        // Verify first 14 fields
+        // Verify first 15 fields
         assertAll("First half of fields should be correctly set",
                 () -> assertEquals(stationType, remarks.automatedStationType()),
                 () -> assertEquals(slp, remarks.seaLevelPressure()),
@@ -4291,6 +4511,7 @@ class NoaaMetarRemarksTest {
                 () -> assertEquals(peakWind, remarks.peakWind()),
                 () -> assertEquals(windShift, remarks.windShift()),
                 () -> assertEquals(windsAtLocation, remarks.windsAtLocation()),
+                () -> assertEquals(directionalWeather, remarks.directionalWeather()),
                 () -> assertEquals(varVis, remarks.variableVisibility()),
                 () -> assertEquals(variableCeiling, remarks.variableCeiling()),
                 () -> assertEquals(ceilingSecondSite, remarks.ceilingSecondSite()),
@@ -4314,6 +4535,10 @@ class NoaaMetarRemarksTest {
                 WindAtLocation.atAltitude(1400, Wind.of(230, 10, "KT")),
                 WindAtLocation.atRunway("26", Wind.calm())
         );
+        DirectionalWeather directionalWeather = new DirectionalWeather(
+                PresentWeather.parse("VCSH"),
+                List.of("E", "SE")
+        );
         Visibility min = Visibility.statuteMiles(0.5);
         Visibility max = Visibility.statuteMiles(2.0);
         VariableVisibility varVis = new VariableVisibility(min, max, null, null);
@@ -4330,6 +4555,7 @@ class NoaaMetarRemarksTest {
         Visibility towerVis = Visibility.statuteMiles(1.5);
         Visibility surfaceVis = Visibility.statuteMiles(0.75);
         PrecipitationAmount hourly = PrecipitationAmount.fromEncoded("0015", 1);
+        Integer ppGroupValue = 102;
         PrecipitationAmount sixHour = PrecipitationAmount.fromEncoded("0025", 6);
         PrecipitationAmount twentyFourHour = PrecipitationAmount.fromEncoded("0125", 24);
         HailSize hailSize = HailSize.inches(1.75);
@@ -4354,15 +4580,16 @@ class NoaaMetarRemarksTest {
         String freeText = "Additional remarks";
 
         NoaaMetarRemarks remarks = new NoaaMetarRemarks(
-                stationType, slp, temp, dewpoint, peakWind, windShift, windsAtLocation, varVis, variableCeiling, ceilingSecondSite,
-                obscurationLayers, cloudTypes, towerVis, surfaceVis, hourly, sixHour, twentyFourHour, hailSize, weatherEvents,
-                thunderstormLocations, tendency, secondaryAltimeter, sixHourMaxTemp, sixHourMinTemp, twentyFourHourMaxTemp,
+                stationType, slp, temp, dewpoint, peakWind, windShift, windsAtLocation, directionalWeather, varVis, variableCeiling,
+                ceilingSecondSite, obscurationLayers, cloudTypes, towerVis, surfaceVis, hourly, ppGroupValue, sixHour, twentyFourHour, hailSize,
+                weatherEvents, thunderstormLocations, tendency, secondaryAltimeter, sixHourMaxTemp, sixHourMinTemp, twentyFourHourMaxTemp,
                 twentyFourHourMinTemp, densityAltitudeFeet, automatedMaintenanceIndicators, maintenanceRequired, freeText
         );
 
-        // Verify remaining 16 fields
+        // Verify remaining 17 fields
         assertAll("Second half of fields should be correctly set",
                 () -> assertEquals(hourly, remarks.hourlyPrecipitation()),
+                () -> assertEquals(ppGroupValue, remarks.ppGroupValue()),
                 () -> assertEquals(sixHour, remarks.sixHourPrecipitation()),
                 () -> assertEquals(twentyFourHour, remarks.twentyFourHourPrecipitation()),
                 () -> assertEquals(hailSize, remarks.hailSize()),

--- a/noakweather-platform/weather-infrastructure/pom.xml
+++ b/noakweather-platform/weather-infrastructure/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.19.2-SNAPSHOT</version>
+        <version>1.19.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-infrastructure</artifactId>

--- a/noakweather-platform/weather-ingestion/pom.xml
+++ b/noakweather-platform/weather-ingestion/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.19.2-SNAPSHOT</version>
+        <version>1.19.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-ingestion</artifactId>

--- a/noakweather-platform/weather-processing/pom.xml
+++ b/noakweather-platform/weather-processing/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.19.2-SNAPSHOT</version>
+        <version>1.19.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-processing</artifactId>

--- a/noakweather-platform/weather-processing/src/main/java/weather/processing/parser/noaa/NoaaMetarParser.java
+++ b/noakweather-platform/weather-processing/src/main/java/weather/processing/parser/noaa/NoaaMetarParser.java
@@ -27,8 +27,7 @@ import weather.utils.IndexedLinkedHashMap;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -895,6 +894,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
             remaining = handleCloudTypeSequential(remaining, remarksBuilder);
             remaining = handleTowerSurfaceVisibilitySequential(remaining, remarksBuilder);
             remaining = handleHourlyPrecipitationSequential(remaining, remarksBuilder);
+            remaining = handlePpGroupSequential(remaining, remarksBuilder);
             remaining = handleMultiHourPrecipitationSequential(remaining, remarksBuilder);
             remaining = handleHailSizeSequential(remaining, remarksBuilder);
             remaining = handleWeatherEventsSequential(remaining, remarksBuilder);
@@ -904,6 +904,7 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
             remaining = handleDensityAltitudeSequential(remaining, remarksBuilder);
             remaining = handleAutomatedMaintenanceSequential(remaining, remarksBuilder);
             remaining = handleSecondaryAltimeterSequential(remaining, remarksBuilder);
+            remaining = handleDirectionalWeatherSequential(remaining, remarksBuilder);
 
             // Continue while we're making progress
         } while (!Objects.equals(remaining, previous));
@@ -1403,6 +1404,97 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
     }
 
     /**
+     * Handle a present-weather phenomenon restated in remarks with associated
+     * compass direction(s) — typically a vicinity phenomenon reported nearby.
+     * Reuses the same PRESENT_WEATHER_PATTERN and PresentWeather parsing as the
+     * main body, since the weather-code grammar is identical; only the trailing
+     * direction list is new.
+     * <p>
+     * Example: RMK VCSH E SE → showers in vicinity, east and southeast
+     *
+     * @param remarksText remaining remarks text to process
+     * @param remarks the remarks builder to populate
+     * @return the remaining text after processing (never null)
+     */
+    private String handleDirectionalWeatherSequential(String remarksText, NoaaMetarRemarks.Builder remarks) {
+        if (remarksText == null || remarksText.trim().isEmpty()) {
+            return remarksText != null ? remarksText : "";
+        }
+
+        String remaining = remarksText.trim();
+
+        // PRESENT_WEATHER_PATTERN requires trailing whitespace, which is absent when
+        // the weather code is the last token in the remarks string. Pad with a
+        // synthetic trailing space so a bare trailing code (e.g. "VCSH") still
+        // matches, without modifying the shared pattern itself.
+        String searchText = remaining.contains(" ") ? remaining : remaining + " ";
+
+        Matcher weatherMatcher = PRESENT_WEATHER_PATTERN.matcher(searchText);
+
+        if (weatherMatcher.find() && weatherMatcher.start() == 0) {
+            remaining = processDirectionalWeatherMatch(weatherMatcher, remaining, remarks);
+        }
+
+        return remaining;
+    }
+
+    /**
+     * Weather codes that are also valid thunderstorm/cloud-location type codes
+     * (TS_CLD_LOC_PATTERN). When PRESENT_WEATHER_PATTERN matches one of these
+     * bare (no intensity/precipitation/obscuration attached), the ambiguity is
+     * resolved in favor of the more specific thunderstorm-location handler.
+     */
+    private static final Set<String> THUNDERSTORM_LOCATION_CODES =
+            Set.of("TS", "CB", "TCU", "ACC", "CBMAM", "VIRGA");
+
+    /**
+     * Process a present-weather match in remarks, then attempt to consume a
+     * trailing direction list.
+     *
+     * @param weatherMatcher the present-weather pattern matcher (must not be null)
+     * @param remaining the remaining text (must not be null)
+     * @param remarks the remarks builder (must not be null)
+     * @return the remaining text after processing (never null)
+     */
+    private String processDirectionalWeatherMatch(Matcher weatherMatcher, String remaining,
+                                                  NoaaMetarRemarks.Builder remarks) {
+        String weatherCode = weatherMatcher.group(0).trim();
+
+        // Ambiguous with thunderstorm/cloud-location remarks (e.g. "TS SE") —
+        // defer to handleThunderstormLocationSequential rather than claiming it here.
+        if (THUNDERSTORM_LOCATION_CODES.contains(weatherCode)) {
+            return remaining;
+        }
+
+        int matchEnd = Math.min(weatherMatcher.end(), remaining.length());
+        String afterWeather = remaining.substring(matchEnd).trim();
+
+        List<String> directions = null;
+        String finalRemaining = afterWeather;
+
+        Matcher directionMatcher = DIRECTION_LIST_PATTERN.matcher(afterWeather);
+        if (directionMatcher.find() && directionMatcher.start() == 0) {
+            directions = Arrays.asList(directionMatcher.group(1).split("\\s+"));
+            finalRemaining = afterWeather.substring(directionMatcher.end()).trim();
+        }
+
+        try {
+            PresentWeather presentWeather = PresentWeather.parse(weatherCode);
+            DirectionalWeather directionalWeather = new DirectionalWeather(presentWeather, directions);
+            remarks.directionalWeather(directionalWeather);
+
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Directional weather: {}", directionalWeather.getSummary());
+            }
+        } catch (IllegalArgumentException e) {
+            LOGGER.warn("Failed to parse directional weather in remarks: {}", weatherCode, e);
+            return remaining;
+        }
+
+        return finalRemaining;
+    }
+
+    /**
      * Handle variable visibility remark for sequential parsing.
      * <p>
      * Format: VIS [DIR] minVmax [RWY]
@@ -1691,6 +1783,44 @@ public class NoaaMetarParser extends NoaaAviationWeatherParser<NoaaMetarData> {
                     remarksText.substring(0, Math.min(20, remarksText.length())), e);
             return remarksText.substring(matcher.end()).trim();
         }
+    }
+
+    /**
+     * Handle the "PP" precipitation-amount group. Format and unit/scale are
+     * not fully confirmed at this time (research inconclusive) — the raw
+     * 3-digit value is captured as-is rather than converted to a specific
+     * unit. Distinct from the US-style single-P hourly precipitation group.
+     * <p>
+     * Example: PP000
+     *
+     * @param remarksText remaining remarks text to process
+     * @param remarks the remarks builder to populate
+     * @return the remaining text after processing (never null)
+     */
+    private String handlePpGroupSequential(String remarksText, NoaaMetarRemarks.Builder remarks) {
+        if (remarksText == null || remarksText.trim().isEmpty()) {
+            return remarksText != null ? remarksText : "";
+        }
+
+        String remaining = remarksText.trim();
+        Matcher matcher = PP_GROUP_PATTERN.matcher(remaining);
+
+        if (matcher.find() && matcher.start() == 0) {
+            try {
+                int value = Integer.parseInt(matcher.group("value"));
+                remarks.ppGroupValue(value);
+
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("PP group value (raw, unit unconfirmed): {}", value);
+                }
+            } catch (NumberFormatException e) {
+                LOGGER.warn("Invalid PP group value in remarks: {}", matcher.group(0), e);
+            }
+
+            remaining = remaining.substring(matcher.end()).trim();
+        }
+
+        return remaining;
     }
 
     /**

--- a/noakweather-platform/weather-processing/src/main/java/weather/processing/parser/noaa/RegExprConst.java
+++ b/noakweather-platform/weather-processing/src/main/java/weather/processing/parser/noaa/RegExprConst.java
@@ -156,6 +156,15 @@ public final class RegExprConst {
     );
 
     /**
+     * One or more space-separated compass directions following a present-weather
+     * remark, e.g. "E SE", "N NE S SW".
+     */
+    @SuppressWarnings("java:S5843") // Complex regex required for precipitation timing format
+    public static final Pattern DIRECTION_LIST_PATTERN = Pattern.compile(
+            "^((?:N|NE|E|SE|S|SW|W|NW)(?:\\s+(?:N|NE|E|SE|S|SW|W|NW))*+)(?=\\s|$)"
+    );
+
+    /**
      * No Significant Change (NOSIG)
      */
     public static final Pattern NO_SIG_CHANGE_PATTERN = Pattern.compile(
@@ -328,6 +337,18 @@ public final class RegExprConst {
      */
     public static final Pattern PRECIP_1HR_PATTERN = Pattern.compile(
             "^(?<type>P)(?<precip>\\d{4}|/{4})\\s*"
+    );
+
+    /**
+     * "PP" precipitation-amount group, distinct from the standard single-P
+     * hourly precipitation group (PRECIP_1HR_PATTERN). Format and semantics
+     * are not fully confirmed. The value is captured raw (3 digits) rather
+     * than converted, pending further research. Observed at SPJC (South America)
+     * but it may not be exclusive to that region.
+     * Example: "PP000"
+     */
+    public static final Pattern PP_GROUP_PATTERN = Pattern.compile(
+            "^PP(?<value>\\d{3})(?=\\s|$)"
     );
 
     /**

--- a/noakweather-platform/weather-processing/src/test/java/weather/processing/parser/noaa/NoaaMetarParserTest.java
+++ b/noakweather-platform/weather-processing/src/test/java/weather/processing/parser/noaa/NoaaMetarParserTest.java
@@ -3314,10 +3314,10 @@ class NoaaMetarParserTest {
         assertTrue(data.getRemarks().windShift().frontalPassage());
     }
 
-    // ========== WIND AT LOCATION TESTS (Issue #62) ==========
+    // ========== WIND AT LOCATION TESTS ==========
 
     @Test
-    @DisplayName("Should parse single wind-at-altitude remark - ENSB real-world (Issue #62)")
+    @DisplayName("Should parse single wind-at-altitude remark - ENSB real-world")
     void testParseWindAtLocation_SingleAltitude_ENSB() {
         String metar = "METAR ENSB 042350Z 23012KT 7000 -SNRA SCT010 BKN020 02/M01 Q1003 RMK WIND 1400FT 23010KT";
 
@@ -3338,7 +3338,7 @@ class NoaaMetarParserTest {
     }
 
     @Test
-    @DisplayName("Should parse chained runway and altitude wind remarks - ENSD real-world (Issue #62)")
+    @DisplayName("Should parse chained runway and altitude wind remarks - ENSD real-world")
     void testParseWindAtLocation_ChainedRunwayAndAltitude_ENSD() {
         String metar = "METAR ENSD 042350Z AUTO VRB01KT 9999 FEW075/// 10/09 Q0996 RMK WIND RWY 26 00000KT WIND 1126FT 00000KT";
 
@@ -3365,7 +3365,7 @@ class NoaaMetarParserTest {
     }
 
     @Test
-    @DisplayName("Should parse single wind-at-altitude remark - ENSG real-world (Issue #62)")
+    @DisplayName("Should parse single wind-at-altitude remark - ENSG real-world")
     void testParseWindAtLocation_SingleAltitude_ENSG() {
         String metar = "METAR ENSG 042350Z AUTO VRB01KT 9999 SCT059/// BKN076/// OVC167/// 08/07 Q0996 RMK WIND 3806FT 18003KT";
 
@@ -3385,7 +3385,7 @@ class NoaaMetarParserTest {
     }
 
     @Test
-    @DisplayName("Should parse single wind-at-altitude remark - ENSH real-world (Issue #62)")
+    @DisplayName("Should parse single wind-at-altitude remark - ENSH real-world")
     void testParseWindAtLocation_SingleAltitude_ENSH() {
         String metar = "METAR ENSH 042350Z 01012KT 9999 NCD 11/08 Q0999 RMK WIND 0150FT 02011KT";
 
@@ -3405,7 +3405,7 @@ class NoaaMetarParserTest {
     }
 
     @Test
-    @DisplayName("Should parse chained runway and altitude wind remarks with VRB direction - ENSR real-world (Issue #62)")
+    @DisplayName("Should parse chained runway and altitude wind remarks with VRB direction - ENSR real-world")
     void testParseWindAtLocation_ChainedWithVrbDirection_ENSR() {
         String metar = "METAR ENSR 042350Z AUTO 06002KT 9999 -DZ FEW007/// SCT012/// BKN019/// 08/06 Q1004 RMK WIND RWY 32 VRB01KT WIND 1119FT VRB03KT";
 
@@ -3429,6 +3429,48 @@ class NoaaMetarParserTest {
         assertThat(altitudeWind.wind().directionDegrees()).isNull();
         assertThat(altitudeWind.wind().hasVariableDirection()).isTrue();
         assertThat(altitudeWind.wind().speedValue()).isEqualTo(3);
+
+        assertThat(data.getRemarks().freeText()).isNull();
+    }
+
+    // ========== DIRECTIONAL WEATHER TESTS ==========
+
+    @Test
+    @DisplayName("Should parse directional weather remark with directions - TNCM real-world")
+    void testParseDirectionalWeather_WithDirections_TNCM() {
+        String metar = "METAR TNCM 020000Z 09008KT 9999 FEW018 SCT300 29/24 A3000 RMK VCSH E SE";
+
+        ParseResult<NoaaWeatherData> result = parser.parse(metar);
+
+        assertTrue(result.isSuccess());
+        NoaaMetarData data = extractMetarData(result);
+
+        assertThat(data.getRemarks().directionalWeather()).isNotNull();
+        DirectionalWeather directionalWeather = data.getRemarks().directionalWeather();
+
+        assertThat(directionalWeather.presentWeather()).isNotNull();
+        assertThat(directionalWeather.hasDirections()).isTrue();
+        assertThat(directionalWeather.directions()).containsExactly("E", "SE");
+
+        assertThat(data.getRemarks().freeText()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should parse bare directional weather remark with no directions")
+    void testParseDirectionalWeather_BareCode_NoDirections() {
+        String metar = "METAR TNCM 020000Z 09008KT 9999 FEW018 SCT300 29/24 A3000 RMK VCSH";
+
+        ParseResult<NoaaWeatherData> result = parser.parse(metar);
+
+        assertTrue(result.isSuccess());
+        NoaaMetarData data = extractMetarData(result);
+
+        assertThat(data.getRemarks().directionalWeather()).isNotNull();
+        DirectionalWeather directionalWeather = data.getRemarks().directionalWeather();
+
+        assertThat(directionalWeather.presentWeather()).isNotNull();
+        assertThat(directionalWeather.hasDirections()).isFalse();
+        assertThat(directionalWeather.directions()).isNull();
 
         assertThat(data.getRemarks().freeText()).isNull();
     }
@@ -4240,6 +4282,38 @@ class NoaaMetarParserTest {
         assertTrue(precip.isTrace(), "Should be trace precipitation");
         assertEquals(1, precip.periodHours());
         assertNull(precip.inches(), "Trace should have null inches");
+    }
+
+    // ========== PP GROUP VALUE TESTS ==========
+
+    @Test
+    @DisplayName("Should parse PP group value - SPJC real-world")
+    void testParsePpGroupValue_SPJC() {
+        String metar = "METAR SPJC 020000Z 18008KT 9999 FEW020 22/18 A3005 RMK PP000";
+
+        ParseResult<NoaaWeatherData> result = parser.parse(metar);
+
+        assertTrue(result.isSuccess());
+        NoaaMetarData data = extractMetarData(result);
+
+        assertThat(data.getRemarks().ppGroupValue()).isZero();
+        assertThat(data.getRemarks().freeText()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should parse PP group value alongside standard hourly precipitation without collision")
+    void testParsePpGroupValue_WithHourlyPrecipitation() {
+        String metar = "METAR SPJC 020000Z 18008KT 9999 FEW020 22/18 A3005 RMK P0010 PP000";
+
+        ParseResult<NoaaWeatherData> result = parser.parse(metar);
+
+        assertTrue(result.isSuccess());
+        NoaaMetarData data = extractMetarData(result);
+
+        assertThat(data.getRemarks().hourlyPrecipitation()).isNotNull();
+        assertThat(data.getRemarks().hourlyPrecipitation().inches()).isEqualTo(0.10, within(0.01));
+        assertThat(data.getRemarks().ppGroupValue()).isZero();
+        assertThat(data.getRemarks().freeText()).isNull();
     }
 
     // ========== 6-HOUR PRECIPITATION PARSING TESTS ==========
@@ -6208,7 +6282,7 @@ class NoaaMetarParserTest {
             "29.77, 'METAR RPLL 020000Z 24010KT 8000 FEW025 SCT100 30/26 Q1008 NOSIG RMK A2977'",
             "29.58, 'METAR RCTP 020000Z 03006KT 9999 FEW010 BKN180 28/26 Q1001 NOSIG RMK A2958'"
     })
-    @DisplayName("Should parse secondary altimeter in remarks - real-world (Issue #56)")
+    @DisplayName("Should parse secondary altimeter in remarks - real-world")
     void testParseSecondaryAltimeter(double expectedInHg, String metar) {
         ParseResult<NoaaWeatherData> result = parser.parse(metar);
 
@@ -7821,7 +7895,7 @@ class NoaaMetarParserTest {
             "700,  'METAR CYVR 020000Z 24008KT 15SM FEW040 SCT100 18/12 A2998 RMK SLP079 DENSITY ALT 700FT'",
             "800,  'METAR CYUL 020000Z 32010KT 10SM SCT050 BKN090 15/08 A2985 RMK SLP165 DENSITY ALT 800FT'"
     })
-    @DisplayName("Should parse density altitude remark - real-world (Issue #57)")
+    @DisplayName("Should parse density altitude remark - real-world")
     void testParseDensityAltitude(int expectedDensityAltFeet, String metar) {
         ParseResult<NoaaWeatherData> result = parser.parse(metar);
 

--- a/noakweather-platform/weather-storage/pom.xml
+++ b/noakweather-platform/weather-storage/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>weather</groupId>
         <artifactId>noakweather-platform</artifactId>
-        <version>1.19.2-SNAPSHOT</version>
+        <version>1.19.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>weather-storage</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>weather</groupId>
     <artifactId>noakweather-engineering-pipeline</artifactId>
-    <version>1.19.2-SNAPSHOT</version>
+    <version>1.19.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>NoakWeather Engineering Pipeline Root</name>


### PR DESCRIPTION
#60, #61

Bump version to 1.19.3-SNAPSHOT.

- Caribbean-region METARs (TNCM) restate a vicinity present-weather code in remarks with trailing compass directions (VCSH E SE). Reuses PRESENT_WEATHER_PATTERN/PresentWeather.parse() rather than duplicating weather-code grammar; confirmed the pattern is already shared correctly with TAF's main body (KNUW), so that path was left untouched. New DirectionalWeather record pairs a PresentWeather with an optional direction list — a bare code with no directions is still captured rather than lost to freeText. Added DIRECTION_LIST_PATTERN and handleDirectionalWeatherSequential(), deliberately ordered last in handleRemarks() since the underlying pattern is broad and risks claiming tokens meant for other handlers.

  Fixed two collisions surfaced by existing tests: bare TS (and CB/TCU/ACC/CBMAM/VIRGA) is ambiguous with TS_CLD_LOC_PATTERN's thunderstorm-location remarks (e.g. TS SE) — excluded these codes when they appear with no other weather qualifiers, deferring to the established handler. PRESENT_WEATHER_PATTERN's mandatory trailing whitespace (same bug class as #56/#57) meant a bare trailing code wouldn't match at all; worked around locally with a synthetic trailing-space pad, without touching the shared pattern. (#60)

- South American METARs (SPJC) report precipitation via a PP + 3-digit group (PP000), distinct from the existing single-P hourly group. Format/unit/scale and time period couldn't be confirmed via available research. Rather than guess, the raw value is captured as-is on a new ppGroupValue (Integer) field — PrecipitationAmount's periodHours is a validated non-nullable int restricted to {1, 3, 6, 24}, with no honest way to represent an unknown period. Field named after the literal token, not the region or an assumed unit. Added PP_GROUP_PATTERN and handlePpGroupSequential(), positioned between the existing hourly and multi-hour precipitation handlers. (#61)

- Fixed DIRECTION_LIST_PATTERN catastrophic-backtracking risk (java:S5998): possessive quantifier over the repeating direction group, consistent with the existing PRESENT_WEATHER_PATTERN fix.

- Added DirectionalWeatherTest, real-world regression tests for TNCM and SPJC in NoaaMetarParserTest, and builder-level tests in NoaaMetarRemarksTest for both new fields.

Full reactor build (wethb.sh + wetht.sh) passing across all modules.

#60 and #61 remain Pending UAT, not closed, pending a full UAT sweep re-run against the worldwide station set.